### PR TITLE
Improve commonAncestor by using a single loop instead of two shift()s

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -24,6 +24,7 @@ define(
 			return nodes;
 		}
 
+
 		/**
 		 * Returns the first common ancestor of the two nodes.
 		 *
@@ -36,15 +37,25 @@ define(
 		 */
 		function commonAncestor(node1, node2) {
 			var parents1 = parents(node1),
-				parents2 = parents(node2);
-			if (parents1[0] != parents2[0]) return null;
-			var commonParent = parents1[0];
-			while (parents1[0] && parents2[0] && parents1[0] == parents2[0]) {
-				commonParent = parents1.shift();
-				parents2.shift();
+				parents2 = parents(node2),
+				parent1 = parents1[0],
+				parent2 = parents2[0];
+
+			if (parent1 != parent2) return null;
+
+			for (var i = 1, l = Math.min(parents1.length, parents2.length); i < l; i++){
+				// Let the commonAncestor be one step behind
+				var commonAncestor = parent1;
+				parent1 = parents1[i];
+				parent2 = parents2[i];
+
+				if (!parent1 || !parent2 || parent1 != parent2)
+					return commonAncestor;
 			}
-			return commonParent;
+			// The common Ancestor is the node itself
+			return parent1;
 		}
+
 
 		/**
 		 * Compares two positions within the document.


### PR DESCRIPTION
See http://jsperf.com/two-array-shift-vs-for

This optimization improves the commonAncestor() function a lot, since this is called a huge bunch of times, this is a viable change.

The signature and behaviour is identical
