### PR TITLE
Shortcut non-trivial case of searching for the common ancestor of two of the same nodes

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -10,9 +10,9 @@ define(
 		 * Get all parents of the given node.
 		 *
 		 * @method parents
-		 * 
+		 *
 		 * @param  {Node}   node  A Node to get it's parents from.
-		 * 
+		 *
 		 * @return {Array}  Array with all parents of node
 		 */
 		function parents(node) {
@@ -28,11 +28,11 @@ define(
 		/**
 		 * Returns the index of the given node in its parent's childNodes.
 		 * Used as an offset, this represents the position just before the given node.
-		 * 
+		 *
 		 * @method getNodeIndex
-		 * 
+		 *
 		 * @param  {Node}    node  The node to determine the index of
-		 * 
+		 *
 		 * @return {Number}  Index of the given node in the parentNode's childNodes.
 		 */
 		function getNodeIndex(node) {
@@ -44,13 +44,17 @@ define(
 		 * Returns the first common ancestor of the two nodes.
 		 *
 		 * @method commonAncestor
-		 * 
+		 *
 		 * @param  {Node}  node1  First node for comparison.
 		 * @param  {Node}  node2  Second node for comparison.
-		 * 
+		 *
 		 * @return {Node}  First common ancestor of the two nodes.
 		 */
 		function commonAncestor(node1, node2) {
+			if (node1 === node2) {
+				return node1;
+			}
+
 			var parents1 = parents(node1),
 				parents2 = parents(node2),
 				parent1 = parents1[0],
@@ -76,12 +80,12 @@ define(
 		 * Compares two positions within the document.
 		 *
 		 * @method comparePoints
-		 * 
+		 *
 		 * @param  {Node}    node1    First node for comparison.
 		 * @param  {Number}  offset1  Initial offset for first node.
 		 * @param  {Node}    node2    Second node for comparison.
 		 * @param  {Number}  offset2  Initial offset for second node.
-		 * 
+		 *
 		 * @return {Number}  Offset between node 1 and 2 expressed as a number.
 		 */
 		function comparePoints(node1, offset1, node2, offset2) {
@@ -110,7 +114,7 @@ define(
 		 * Queues mutation on all target nodes, and on all target nodes of all its ancestors.
 		 *
 		 * @method queueMutationRecord
-		 * 
+		 *
 		 * @param  {MutationRecord}  mutationRecord  The MutationRecord to queue.
 		 */
 		function queueMutationRecord(mutationRecord) {
@@ -123,7 +127,7 @@ define(
 
 		/**
 		 * Slimdom utility functions, intended for internal usage by the slimdom module.
-		 * 
+		 *
 		 * @class util
 		 * @static
 		 * @private


### PR DESCRIPTION
Calling Range#setStart / setEnd on a new range will place the other part
at the same place. When dealing with a large amount of ranges, this may
get quite expensive.