### PR TITLE
Use a single array to build the serialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "slimdom",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"description": "Fast, tiny DOM implementation in pure JS",
 	"author": "Stef Busking",
 	"license": "MIT",

--- a/src/dom-parsing/XMLSerializer.ts
+++ b/src/dom-parsing/XMLSerializer.ts
@@ -5,7 +5,7 @@ import { produceXmlSerialization } from './serializationAlgorithms';
 export default class XMLSerializer {
 	/**
 	 * Constructs a new XMLSerializer object.
-	*/
+	 */
 	public constructor() {}
 
 	/**
@@ -21,7 +21,9 @@ export default class XMLSerializer {
 
 		// Produce an XML serialization of root passing a value of false for the require well-formed
 		// parameter, and return the result.
-		return produceXmlSerialization(root, false);
+		const result: string[] = [];
+		produceXmlSerialization(root, false, result);
+		return result.join('');
 	}
 }
 
@@ -41,5 +43,7 @@ export function serializeToWellFormedString(root: Node): string {
 
 	// Produce an XML serialization of root passing a value of false for the require well-formed
 	// parameter, and return the result.
-	return produceXmlSerialization(root, true);
+	const result: string[] = [];
+	produceXmlSerialization(root, true, result);
+	return result.join('');
 }

--- a/test/dom-parsing/XMLSerializer.tests.ts
+++ b/test/dom-parsing/XMLSerializer.tests.ts
@@ -415,4 +415,11 @@ describe('serializeToWellFormedString', () => {
 		pi.appendData('?>test');
 		chai.assert.throws(() => slimdom.serializeToWellFormedString(pi), 'InvalidStateError');
 	});
+
+	it('can serialize normally if there are no well-formedness violations', () => {
+		chai.assert.equal(
+			slimdom.serializeToWellFormedString(document.createElement('el')),
+			'<el/>'
+		);
+	});
 });

--- a/test/web-platform-tests/webPlatform.tests.ts
+++ b/test/web-platform-tests/webPlatform.tests.ts
@@ -431,12 +431,12 @@ function getAllScripts(doc: slimdom.Document, casePath: string) {
 					// Historical alias, unfortunately not an actual file
 					// https://github.com/w3c/web-platform-tests/issues/5608
 					resolvedPath = path.resolve(
-						process.env.WEB_PLATFORM_TESTS_PATH,
+						process.env.WEB_PLATFORM_TESTS_PATH as string,
 						'resources/webidl2/lib/webidl2.js'
 					);
 				} else {
 					resolvedPath = src.value.startsWith('/')
-						? path.resolve(process.env.WEB_PLATFORM_TESTS_PATH, src.value.substring(1))
+						? path.resolve(process.env.WEB_PLATFORM_TESTS_PATH as string, src.value.substring(1))
 						: path.resolve(path.dirname(casePath), src.value);
 				}
 				return scripts.concat([fs.readFileSync(resolvedPath, 'utf-8')]);
@@ -564,7 +564,7 @@ function createTest(casePath: string, blacklistReason: { [key: string]: string }
 function createTests(dirPath: string): void {
 	fs.readdirSync(dirPath).forEach(entry => {
 		const entryPath = path.join(dirPath, entry);
-		const relativePath = path.relative(process.env.WEB_PLATFORM_TESTS_PATH, entryPath);
+		const relativePath = path.relative(process.env.WEB_PLATFORM_TESTS_PATH as string, entryPath);
 		const blacklistReason = TEST_BLACKLIST[relativePath.replace(/\\/g, '/')];
 		if (typeof blacklistReason === 'string') {
 			// Create a pending test
@@ -699,5 +699,5 @@ describe('web platform DOM test suite', () => {
 		}
 	});
 
-	createTests(path.join(process.env.WEB_PLATFORM_TESTS_PATH, 'dom'));
+	createTests(path.join(process.env.WEB_PLATFORM_TESTS_PATH as string, 'dom'));
 });


### PR DESCRIPTION
Using array.push.apply can run into stack overflows when applied to very large arrays.