### PR TITLE
Do not output multiple namespace declarations

### DIFF
--- a/src/dom-parsing/serializationAlgorithms.ts
+++ b/src/dom-parsing/serializationAlgorithms.ts
@@ -774,6 +774,10 @@ function serializeAttributes(
 						candidatePrefix = attr.prefix;
 					}
 
+					// Update the local and aggregate prefixes to account for the new declaration.
+					map.add(candidatePrefix, attr.namespaceURI);
+					localPrefixesMap[candidatePrefix] = attr.namespaceURI;
+
 					// 3.5.3.2. Append the following to result, in the order listed:
 					// 3.5.3.2.1. " " (U+0020 SPACE);
 					// 3.5.3.2.2. The string "xmlns:";


### PR DESCRIPTION
When setting multiple attributes with identical namespaceURI/prefix combinations, serialization
outputten more than one identical namespace declaration. By remembering which namespace declarations
have already been outputted, we can make sure we only output one.

I have also added a number of tests for related possible bugs. This brings test coverage back to
100%.

This fixes #57.