### PR TITLE
Generics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,15 @@
 {
 	"name": "slimdom",
 	"version": "2.1.3",
-	"description":
-		"Fast, tiny, standards-compliant XML DOM implementation for node and the browser",
+	"description": "Fast, tiny, standards-compliant XML DOM implementation for node and the browser",
 	"author": "Stef Busking",
 	"license": "MIT",
-	"keywords": ["dom", "xml", "XMLSerializer", "w3c"],
+	"keywords": [
+		"dom",
+		"xml",
+		"XMLSerializer",
+		"w3c"
+	],
 	"main": "dist/slimdom.js",
 	"module": "dist/slimdom.mjs",
 	"scripts": {
@@ -18,29 +22,39 @@
 		"test": "jest --coverage --verbose",
 		"test:debug": "node --inspect --debug-brk node_modules/jest/bin/jest.js --runInBand"
 	},
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"repository": {
 		"type": "git",
 		"url": "git://github.com/bwrrp/slimdom.js.git"
 	},
 	"devDependencies": {
-		"@types/jest": "^22.1.3",
-		"jest": "^22.4.0",
-		"prettier": "^1.10.2",
+		"@types/jest": "^23.3.1",
+		"jest": "^23.5.0",
+		"prettier": "^1.14.2",
 		"rimraf": "^2.6.2",
-		"rollup": "^0.57.0",
-		"rollup-plugin-babel-minify": "^4.0.0",
-		"ts-jest": "^22.0.4",
-		"typedoc": "^0.11.0",
-		"typescript": "^2.7.2"
+		"rollup": "^0.64.1",
+		"rollup-plugin-babel-minify": "^5.0.0",
+		"ts-jest": "^23.1.3",
+		"typedoc": "^0.12.0",
+		"typescript": "^3.0.1"
 	},
 	"jest": {
 		"transform": {
 			"^.+\\.tsx?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
 		},
 		"testRegex": "(\\.(tests))\\.(tsx?|jsx?)$",
-		"moduleFileExtensions": ["ts", "tsx", "js", "json", "jsx"],
-		"collectCoverageFrom": ["src/**/*.ts"]
+		"moduleFileExtensions": [
+			"ts",
+			"tsx",
+			"js",
+			"json",
+			"jsx"
+		],
+		"collectCoverageFrom": [
+			"src/**/*.ts"
+		]
 	},
 	"prettier": {
 		"printWidth": 100,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,11 +5,9 @@ const { main: MAIN_DEST_FILE, module: MODULE_DEST_FILE } = require('./package.js
 export default {
 	input: 'lib/index.js',
 	output: [
-		{ file: MAIN_DEST_FILE, format: 'umd', exports: 'named' },
-		{ file: MODULE_DEST_FILE, format: 'es' }
+		{ name: 'slimdom', file: MAIN_DEST_FILE, format: 'umd', exports: 'named', sourcemap: true },
+		{ file: MODULE_DEST_FILE, format: 'es', sourcemap: true }
 	],
-	name: 'slimdom',
-	sourcemap: true,
 	onwarn(warning) {
 		// Ignore "this is undefined" warning triggered by typescript's __extends helper
 		if (warning.code === 'THIS_IS_UNDEFINED') {

--- a/src/Document.ts
+++ b/src/Document.ts
@@ -290,7 +290,7 @@ export default class Document extends Node implements NonElementParentNode, Pare
 	 * @param node The node to import
 	 * @param deep Whether to also import node's children
 	 */
-	public importNode(node: Node, deep: boolean = false): Node {
+	public importNode<TNode extends Node>(node: TNode, deep: boolean = false): TNode {
 		expectArity(arguments, 1);
 		node = asObject(node, Node);
 
@@ -311,7 +311,7 @@ export default class Document extends Node implements NonElementParentNode, Pare
 	 *
 	 * @param node The node to adopt
 	 */
-	public adoptNode(node: Node): Node {
+	public adoptNode<TNode extends Node>(node: TNode): TNode {
 		expectArity(arguments, 1);
 		node = asObject(node, Node);
 

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -58,7 +58,7 @@ export default abstract class Node {
 	 */
 	public get parentElement(): Element | null {
 		return this.parentNode && isNodeOfType(this.parentNode, NodeType.ELEMENT_NODE)
-			? this.parentNode as Element
+			? (this.parentNode as Element)
 			: null;
 	}
 
@@ -222,7 +222,7 @@ export default abstract class Node {
 	 *
 	 * @return A copy of the current node
 	 */
-	public cloneNode(deep: boolean = false): Node {
+	public cloneNode(deep: boolean = false): this {
 		return cloneNode(this, deep);
 	}
 
@@ -297,7 +297,7 @@ export default abstract class Node {
 	 *
 	 * @return The node that was inserted
 	 */
-	public insertBefore(node: Node, child: Node | null): Node {
+	public insertBefore<TNode extends Node>(node: TNode, child: Node | null): TNode {
 		expectArity(arguments, 2);
 		node = asObject(node, Node);
 		child = asNullableObject(child, Node);
@@ -314,7 +314,7 @@ export default abstract class Node {
 	 *
 	 * @return The node that was inserted
 	 */
-	public appendChild(node: Node): Node {
+	public appendChild<TNode extends Node>(node: TNode): TNode {
 		expectArity(arguments, 1);
 		node = asObject(node, Node);
 
@@ -329,7 +329,7 @@ export default abstract class Node {
 	 *
 	 * @return The node that was removed
 	 */
-	public replaceChild(node: Node, child: Node): Node {
+	public replaceChild<TChild extends Node>(node: Node, child: TChild): TChild {
 		expectArity(arguments, 2);
 		node = asObject(node, Node);
 		child = asObject(child, Node);
@@ -344,7 +344,7 @@ export default abstract class Node {
 	 *
 	 * @return The node that was removed
 	 */
-	public removeChild(child: Node): Node {
+	public removeChild<TChild extends Node>(child: TChild): TChild {
 		expectArity(arguments, 1);
 		child = asObject(child, Node);
 

--- a/src/util/cloneNode.ts
+++ b/src/util/cloneNode.ts
@@ -13,7 +13,11 @@ import { getNodeDocument } from './treeHelpers';
  * @param cloneChildren Whether to also clone node's descendants
  * @param document      The document used to create the copy
  */
-export default function cloneNode(node: Node, cloneChildren: boolean, document?: Document): Node {
+export default function cloneNode<TNode extends Node>(
+	node: TNode,
+	cloneChildren: boolean,
+	document?: Document
+): TNode {
 	// 1. If document is not given, let document be node’s node document.
 	if (!document) {
 		document = getNodeDocument(node);
@@ -37,7 +41,7 @@ export default function cloneNode(node: Node, cloneChildren: boolean, document?:
 	// 4. Set copy’s node document and document to copy, if copy is a document, and set copy’s node
 	// document to document otherwise.
 	// (all handled by _copy method)
-	let copy = node._copy(document);
+	let copy = node._copy(document) as TNode;
 
 	// 5. Run any cloning steps defined for node in other applicable specifications and pass copy,
 	// node, document and the clone children flag if set, as parameters.

--- a/src/util/mutationAlgorithms.ts
+++ b/src/util/mutationAlgorithms.ts
@@ -161,7 +161,11 @@ function ensurePreInsertionValidity(node: Node, parent: Node, child: Node | null
  *
  * @return The inserted node
  */
-export function preInsertNode(node: Node, parent: Node, child: Node | null): Node {
+export function preInsertNode<TNode extends Node>(
+	node: TNode,
+	parent: Node,
+	child: Node | null
+): TNode {
 	// 1. Ensure pre-insertion validity of node into parent before child.
 	ensurePreInsertionValidity(node, parent, child);
 
@@ -294,7 +298,7 @@ export function insertNode(
  *
  * @return The appended node
  */
-export function appendNode(node: Node, parent: Node): Node {
+export function appendNode<TNode extends Node>(node: TNode, parent: Node): TNode {
 	// pre-insert node into parent before null.
 	return preInsertNode(node, parent, null);
 }
@@ -308,7 +312,11 @@ export function appendNode(node: Node, parent: Node): Node {
  *
  * @return The old child node
  */
-export function replaceChildWithNode(child: Node, node: Node, parent: Node): Node {
+export function replaceChildWithNode<TChild extends Node>(
+	child: TChild,
+	node: Node,
+	parent: Node
+): TChild {
 	// 1. If parent is not a Document, DocumentFragment, or Element node, throw a
 	// HierarchyRequestError.
 	if (
@@ -389,7 +397,8 @@ export function replaceChildWithNode(child: Node, node: Node, parent: Node): Nod
 				// that is not child or a doctype is following child.
 				if (
 					fragment.firstElementChild &&
-					((parentDocument.documentElement && parentDocument.documentElement !== child) ||
+					((parentDocument.documentElement &&
+						parentDocument.documentElement !== (child as Node)) ||
 						(child &&
 							parentDocument.doctype &&
 							getNodeIndex(child) < getNodeIndex(parentDocument.doctype)))
@@ -405,7 +414,8 @@ export function replaceChildWithNode(child: Node, node: Node, parent: Node): Nod
 			case NodeType.ELEMENT_NODE:
 				// parent has an element child that is not child or a doctype is following child.
 				if (
-					(parentDocument.documentElement && parentDocument.documentElement !== child) ||
+					(parentDocument.documentElement &&
+						parentDocument.documentElement !== (child as Node)) ||
 					(parentDocument.doctype &&
 						getNodeIndex(child) < getNodeIndex(parentDocument.doctype))
 				) {
@@ -420,7 +430,7 @@ export function replaceChildWithNode(child: Node, node: Node, parent: Node): Nod
 			case NodeType.DOCUMENT_TYPE_NODE:
 				// parent has a doctype child that is not child, or an element is preceding child.
 				if (
-					(parentDocument.doctype && parentDocument.doctype !== child) ||
+					(parentDocument.doctype && parentDocument.doctype !== (child as Node)) ||
 					(parentDocument.documentElement &&
 						getNodeIndex(parentDocument.documentElement) < getNodeIndex(child))
 				) {
@@ -491,7 +501,7 @@ export function replaceChildWithNode(child: Node, node: Node, parent: Node): Nod
  *
  * @return The removed child
  */
-export function preRemoveChild(child: Node, parent: Node): Node {
+export function preRemoveChild<TChild extends Node>(child: TChild, parent: Node): TChild {
 	// 1. If child’s parent is not parent, then throw a NotFoundError.
 	if (child.parentNode !== parent) {
 		throwNotFoundError('child is not a child of parent');

--- a/src/util/treeHelpers.ts
+++ b/src/util/treeHelpers.ts
@@ -68,7 +68,7 @@ export function getNodeDocument(node: Node): Document {
  * @return The index of node in its parent's children
  */
 export function getNodeIndex(node: Node): number {
-	return (node.parentNode as Node).childNodes.indexOf(node);
+	return node.parentNode!.childNodes.indexOf(node);
 }
 
 /**

--- a/test/Attr.tests.ts
+++ b/test/Attr.tests.ts
@@ -64,7 +64,7 @@ describe('Attr', () => {
 		const attr = document.createAttributeNS('http://www.example.com/ns', 'ns:test');
 		attr.value = 'some value';
 
-		const copy = attr.cloneNode() as slimdom.Attr;
+		const copy = attr.cloneNode();
 		expect(copy.nodeType).toBe(2);
 		expect(copy.nodeName).toBe('ns:test');
 		expect(copy.nodeValue).toBe('some value');

--- a/test/CDATASection.tests.ts
+++ b/test/CDATASection.tests.ts
@@ -16,7 +16,7 @@ describe('CDATASection', () => {
 
 	it('can be cloned', () => {
 		const cs = document.createCDATASection('some content');
-		const copy = cs.cloneNode() as slimdom.CDATASection;
+		const copy = cs.cloneNode();
 		expect(copy.nodeType).toBe(4);
 		expect(copy.nodeName).toBe('#cdata-section');
 		expect(copy.nodeValue).toBe('some content');

--- a/test/Comment.tests.ts
+++ b/test/Comment.tests.ts
@@ -57,7 +57,7 @@ describe('Comment', () => {
 
 	it('can be cloned', () => {
 		const comment = document.createComment('some data');
-		var copy = comment.cloneNode() as slimdom.Comment;
+		var copy = comment.cloneNode();
 		expect(copy.nodeType).toBe(8);
 		expect(copy.nodeName).toBe('#comment');
 		expect(copy.nodeValue).toBe('some data');

--- a/test/DOMImplementation.tests.ts
+++ b/test/DOMImplementation.tests.ts
@@ -45,7 +45,7 @@ describe('DOMImplementation', () => {
 			const document = domImplementation.createDocument(null, 'someRootElementName');
 			expect(document.nodeType).toBe(9);
 			expect(document.firstChild).toBe(document.documentElement);
-			expect((document.documentElement as slimdom.Element).nodeName).toBe(
+			expect(document.documentElement!.nodeName).toBe(
 				'someRootElementName'
 			);
 		});

--- a/test/Document.tests.ts
+++ b/test/Document.tests.ts
@@ -120,7 +120,7 @@ describe('Document', () => {
 		});
 
 		it('can be cloned (shallow)', () => {
-			const copy = document.cloneNode() as slimdom.Document;
+			const copy = document.cloneNode();
 
 			expect(copy.nodeType).toBe(9);
 			expect(copy.nodeName).toBe('#document');
@@ -132,7 +132,7 @@ describe('Document', () => {
 		});
 
 		it('can be cloned (deep)', () => {
-			const copy = document.cloneNode(true) as slimdom.Document;
+			const copy = document.cloneNode(true);
 
 			expect(copy.nodeType).toBe(9);
 			expect(copy.nodeName).toBe('#document');
@@ -236,7 +236,7 @@ describe('Document', () => {
 				.appendChild(otherDocument.createElement('child'))
 				.appendChild(otherDocument.createTextNode('content'));
 			expect(element.ownerDocument).toBe(otherDocument);
-			const copy = document.importNode(element, true) as slimdom.Element;
+			const copy = document.importNode(element, true);
 			expect(copy.ownerDocument).toBe(document);
 			expect(copy.nodeName).toBe(element.nodeName);
 			expect(copy).not.toBe(element);
@@ -281,7 +281,7 @@ describe('Document', () => {
 				.appendChild(otherDocument.createTextNode('content'));
 			element.setAttribute('test', 'value');
 			expect(element.ownerDocument).toBe(otherDocument);
-			const adopted = document.adoptNode(element) as slimdom.Element;
+			const adopted = document.adoptNode(element);
 			expect(adopted.ownerDocument).toBe(document);
 			expect(adopted.nodeName).toBe(element.nodeName);
 			expect(adopted).toBe(element);

--- a/test/DocumentFragment.tests.ts
+++ b/test/DocumentFragment.tests.ts
@@ -40,11 +40,11 @@ describe('DocumentFragment', () => {
 	it('initially has no children', () => expect(fragment.children).toEqual([]));
 
 	it('correctly updates its relation properties when children are added', () => {
-		const child1 = fragment.appendChild(document.createElement('child1')) as slimdom.Element;
+		const child1 = fragment.appendChild(document.createElement('child1'));
 		const text = fragment.appendChild(document.createTextNode('text'));
-		const child2 = fragment.appendChild(document.createElement('child2')) as slimdom.Element;
+		const child2 = fragment.appendChild(document.createElement('child2'));
 		const pi = fragment.appendChild(document.createProcessingInstruction('target', 'data'));
-		const child3 = fragment.appendChild(document.createElement('child3')) as slimdom.Element;
+		const child3 = fragment.appendChild(document.createElement('child3'));
 		expect(fragment.childNodes).toEqual([child1, text, child2, pi, child3]);
 		expect(fragment.children).toEqual([child1, child2, child3]);
 		expect(fragment.firstElementChild).toBe(child1);
@@ -61,11 +61,11 @@ describe('DocumentFragment', () => {
 	});
 
 	it('inserts its children if inserted under another node', () => {
-		const child1 = fragment.appendChild(document.createElement('child1')) as slimdom.Element;
+		const child1 = fragment.appendChild(document.createElement('child1'));
 		const text = fragment.appendChild(document.createTextNode('text'));
-		const child2 = fragment.appendChild(document.createElement('child2')) as slimdom.Element;
+		const child2 = fragment.appendChild(document.createElement('child2'));
 		const pi = fragment.appendChild(document.createProcessingInstruction('target', 'data'));
-		const child3 = fragment.appendChild(document.createElement('child3')) as slimdom.Element;
+		const child3 = fragment.appendChild(document.createElement('child3'));
 		const parent = document.createElement('parent');
 		const existingChild = parent.appendChild(document.createComment('test'));
 		parent.insertBefore(fragment, existingChild);
@@ -83,7 +83,7 @@ describe('DocumentFragment', () => {
 		});
 
 		it('can be cloned (shallow)', () => {
-			const copy = fragment.cloneNode() as slimdom.DocumentFragment;
+			const copy = fragment.cloneNode();
 
 			expect(copy.nodeType).toBe(11);
 			expect(copy.nodeName).toBe('#document-fragment');
@@ -95,7 +95,7 @@ describe('DocumentFragment', () => {
 		});
 
 		it('can be cloned (deep)', () => {
-			const copy = fragment.cloneNode(true) as slimdom.DocumentFragment;
+			const copy = fragment.cloneNode(true);
 
 			expect(copy.nodeType).toBe(11);
 			expect(copy.nodeName).toBe('#document-fragment');

--- a/test/DocumentType.tests.ts
+++ b/test/DocumentType.tests.ts
@@ -33,7 +33,7 @@ describe('DocumentType', () => {
 	});
 
 	it('can be cloned', () => {
-		const copy = doctype.cloneNode(true) as slimdom.DocumentType;
+		const copy = doctype.cloneNode(true);
 		expect(copy.nodeType).toBe(10);
 		expect(copy.name).toBe('somename');
 		expect(copy.publicId).toBe('somePublicId');

--- a/test/Element.tests.ts
+++ b/test/Element.tests.ts
@@ -536,7 +536,7 @@ describe('Element', () => {
 		});
 
 		it('can be cloned (shallow)', () => {
-			const copy = element.cloneNode() as slimdom.Element;
+			const copy = element.cloneNode();
 
 			expect(copy.nodeType).toBe(1);
 			expect(copy.nodeName).toBe('svg:g');
@@ -553,7 +553,7 @@ describe('Element', () => {
 		});
 
 		it('can be cloned (deep)', () => {
-			const copy = element.cloneNode(true) as slimdom.Element;
+			const copy = element.cloneNode(true);
 
 			expect(copy.nodeType).toBe(1);
 			expect(copy.nodeName).toBe('svg:g');

--- a/test/MutationObserver.tests.ts
+++ b/test/MutationObserver.tests.ts
@@ -90,7 +90,7 @@ describe('MutationObserver', () => {
 	const cases: { [description: string]: TestCase } = {
 		'responds to text changes': observer => {
 			const element = document.createElement('test');
-			const text = element.appendChild(document.createTextNode('text')) as slimdom.Text;
+			const text = element.appendChild(document.createTextNode('text'));
 			observer.observe(element, { subtree: true, characterData: true });
 
 			text.data = 'meep';
@@ -100,7 +100,7 @@ describe('MutationObserver', () => {
 
 		'records previous text values': observer => {
 			const element = document.createElement('test');
-			const text = element.appendChild(document.createTextNode('text')) as slimdom.Text;
+			const text = element.appendChild(document.createTextNode('text'));
 			observer.observe(element, { subtree: true, characterDataOldValue: true });
 
 			text.data = 'meep';
@@ -311,7 +311,7 @@ describe('MutationObserver', () => {
 		},
 
 		'does not respond to subtree mutations if the subtree option is not set': observer => {
-			const element = document.appendChild(document.createElement('test')) as slimdom.Element;
+			const element = document.appendChild(document.createElement('test'));
 			observer.observe(document, { attributes: true, childList: true });
 			element.appendChild(document.createElement('child'));
 			element.setAttribute('test', 'value');
@@ -340,7 +340,7 @@ describe('MutationObserver', () => {
 		'continues tracking under a removed node until javascript re-enters the event loop': observer => {
 			const parent = document.appendChild(document.createElement('parent'));
 			const child = parent.appendChild(document.createElement('child'));
-			const text = child.appendChild(document.createTextNode('text')) as slimdom.Text;
+			const text = child.appendChild(document.createTextNode('text'));
 			observer.observe(document, {
 				childList: true,
 				characterDataOldValue: true,
@@ -372,7 +372,7 @@ describe('MutationObserver', () => {
 		'does not add transient registered observers for non-subtree observers': observer => {
 			const parent = document.appendChild(document.createElement('parent'));
 			const child = parent.appendChild(document.createElement('child'));
-			const text = child.appendChild(document.createTextNode('text')) as slimdom.Text;
+			const text = child.appendChild(document.createTextNode('text'));
 			observer.observe(document, {
 				childList: true,
 				characterDataOldValue: true,
@@ -394,7 +394,7 @@ describe('MutationObserver', () => {
 		'removes transient observers when observe is called for the same observer': observer => {
 			const parent = document.appendChild(document.createElement('parent'));
 			const child = parent.appendChild(document.createElement('child'));
-			const text = child.appendChild(document.createTextNode('text')) as slimdom.Text;
+			const text = child.appendChild(document.createTextNode('text'));
 			observer.observe(document, {
 				childList: true,
 				characterDataOldValue: true,
@@ -421,7 +421,7 @@ describe('MutationObserver', () => {
 		'does not remove transient observers when observe is called for a different observer': observer => {
 			const parent = document.appendChild(document.createElement('parent'));
 			const child = parent.appendChild(document.createElement('child'));
-			const text = child.appendChild(document.createTextNode('text')) as slimdom.Text;
+			const text = child.appendChild(document.createTextNode('text'));
 			observer.observe(document, {
 				childList: true,
 				characterDataOldValue: true,

--- a/test/ProcessingInstruction.tests.ts
+++ b/test/ProcessingInstruction.tests.ts
@@ -18,7 +18,7 @@ describe('ProcessingInstruction', () => {
 
 	it('can be cloned', () => {
 		const pi = document.createProcessingInstruction('sometarget', 'some data');
-		var copy = pi.cloneNode() as slimdom.ProcessingInstruction;
+		var copy = pi.cloneNode();
 		expect(copy.nodeType).toBe(7);
 		expect(copy.nodeName).toBe('sometarget');
 		expect(copy.nodeValue).toBe('some data');

--- a/test/Range.tests.ts
+++ b/test/Range.tests.ts
@@ -7,8 +7,8 @@ describe('Range', () => {
 	let range: slimdom.Range;
 	beforeEach(() => {
 		document = new slimdom.Document();
-		element = document.appendChild(document.createElement('root')) as slimdom.Element;
-		text = element.appendChild(document.createTextNode('text')) as slimdom.Text;
+		element = document.appendChild(document.createElement('root'));
+		text = element.appendChild(document.createTextNode('text'));
 		range = document.createRange();
 	});
 

--- a/test/Text.tests.ts
+++ b/test/Text.tests.ts
@@ -56,7 +56,7 @@ describe('Text', () => {
 
 	it('can be cloned', () => {
 		const text = document.createTextNode('some data');
-		var copy = text.cloneNode() as slimdom.Text;
+		var copy = text.cloneNode();
 		expect(copy.nodeType).toBe(3);
 		expect(copy.nodeName).toBe('#text');
 		expect(copy.nodeValue).toBe('some data');

--- a/test/dom-parsing/Element.innerHTML.tests.ts
+++ b/test/dom-parsing/Element.innerHTML.tests.ts
@@ -10,7 +10,7 @@ describe('Element#innerHTML', () => {
 		const el = document.createElement('test');
 		el.setAttribute('attr', 'value');
 		el.appendChild(document.createTextNode('test'));
-		const child = el.appendChild(document.createElement('child')) as slimdom.Element;
+		const child = el.appendChild(document.createElement('child'));
 		child.setAttribute('childAttr', 'childValue');
 		expect(el.innerHTML).toBe('test<child childAttr="childValue"/>');
 	});

--- a/test/dom-parsing/Element.outerHTML.tests.ts
+++ b/test/dom-parsing/Element.outerHTML.tests.ts
@@ -12,7 +12,7 @@ describe('Element#outerHTML', () => {
 		document.appendChild(document.createComment('sibling'));
 		el.setAttribute('attr', 'value');
 		el.appendChild(document.createTextNode('test'));
-		const child = el.appendChild(document.createElement('child')) as slimdom.Element;
+		const child = el.appendChild(document.createElement('child'));
 		child.setAttribute('childAttr', 'childValue');
 		expect(el.outerHTML).toBe('<test attr="value">test<child childAttr="childValue"/></test>');
 	});

--- a/test/mutationAlgorithms.tests.ts
+++ b/test/mutationAlgorithms.tests.ts
@@ -85,7 +85,7 @@ describe('DOM mutations', () => {
 
 		it('allows inserting a document element using a fragment', () => {
 			const fragment = document.createDocumentFragment();
-			const child = fragment.appendChild(document.createElement('child1')) as slimdom.Element;
+			const child = fragment.appendChild(document.createElement('child1'));
 			const doctype = document.appendChild(
 				document.implementation.createDocumentType('html', '', '')
 			);
@@ -116,10 +116,8 @@ describe('DOM mutations', () => {
 		});
 
 		it('correctly handles inserting a node before itself', () => {
-			const parent = document.appendChild(
-				document.createElement('parent')
-			) as slimdom.Element;
-			const element = parent.appendChild(document.createElement('child')) as slimdom.Element;
+			const parent = document.appendChild(document.createElement('parent'));
+			const element = parent.appendChild(document.createElement('child'));
 			parent.insertBefore(element, element);
 			expect(parent.firstElementChild).toBe(element);
 			expect(element.nextElementSibling).toBe(null);
@@ -127,7 +125,7 @@ describe('DOM mutations', () => {
 		});
 
 		it('throws if inserting the document element before itself', () => {
-			const element = document.appendChild(document.createElement('test')) as slimdom.Element;
+			const element = document.appendChild(document.createElement('test'));
 			expect(() => document.insertBefore(element, element)).toThrow('HierarchyRequestError');
 		});
 
@@ -242,7 +240,7 @@ describe('DOM mutations', () => {
 
 		it('allows inserting a document element using a fragment', () => {
 			const fragment = document.createDocumentFragment();
-			const child = fragment.appendChild(document.createElement('child1')) as slimdom.Element;
+			const child = fragment.appendChild(document.createElement('child1'));
 			const doctype = document.appendChild(
 				document.implementation.createDocumentType('html', '', '')
 			);
@@ -284,10 +282,8 @@ describe('DOM mutations', () => {
 		});
 
 		it('correctly handles replacing a node with itself', () => {
-			const parent = document.appendChild(
-				document.createElement('parent')
-			) as slimdom.Element;
-			const element = parent.appendChild(document.createElement('child')) as slimdom.Element;
+			const parent = document.appendChild(document.createElement('parent'));
+			const element = parent.appendChild(document.createElement('child'));
 			parent.replaceChild(element, element);
 			expect(parent.firstElementChild).toBe(element);
 			expect(element.nextElementSibling).toBe(null);
@@ -295,11 +291,9 @@ describe('DOM mutations', () => {
 		});
 
 		it('correctly handles replacing a node with its next sibling', () => {
-			const parent = document.appendChild(
-				document.createElement('parent')
-			) as slimdom.Element;
-			const element1 = parent.appendChild(document.createElement('child')) as slimdom.Element;
-			const element2 = parent.appendChild(document.createElement('child')) as slimdom.Element;
+			const parent = document.appendChild(document.createElement('parent'));
+			const element1 = parent.appendChild(document.createElement('child'));
+			const element2 = parent.appendChild(document.createElement('child'));
 			parent.replaceChild(element2, element1);
 			expect(parent.firstElementChild).toBe(element2);
 			expect(element2.nextElementSibling).toBe(null);


### PR DESCRIPTION
This updates the types of a few methods to use generics, in order to make things like cloneNode and appendChild directly return the expected subtype of Node rather than requiring a cast.

It is not completely clear whether this use of the `this` type (for cloneNode) is correct. Comments on the relevant Typescript issues range between "this also solves clone methods" and "this is only for method chaining". It seems that the compiler does allow returning a different instance of the type (instead of only allowing returning the this reference), so everything does type-check as intended.