### PR TITLE
Fix running the unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 			"^.+\\.tsx?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
 		},
 		"testRegex": "(\\.(tests))\\.(tsx?|jsx?)$",
+		"testURL": "http://localhost",
 		"moduleFileExtensions": ["ts", "tsx", "js", "json", "jsx"],
 		"collectCoverageFrom": ["src/**/*.ts"]
 	},


### PR DESCRIPTION
See https://github.com/facebook/jest/issues/6766 for more info.

This is the reason why greenkeeper has been spamming build failures for a while now.