### PR TITLE
Export required functions for connecting an HTML5 parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The following features have not yet been implemented:
 
 -   No XML parsing (no `DOMParser`, `innerHTML` and `outerHTML` are read-only). If you need to parse XML, consider using [slimdom-sax-parser][slimdom-sax-parser].
 -   No CSS selectors, so no `querySelector` / `querySelectorAll` on `ParentNode`, no `closest` / `matches` / `webkitMatchesSelector` on `Element`. The older non-CSS query methods (`getElementById` for interface `NonElementParentNode`, and `getElementsByTagName` / `getElementsByTagNameNS` / `getElementsByClassName` on `Document`) have not yet been implemented either. To query the DOM, consider using [FontoXPath][fontoxpath].
--   No HTML parsing / serialization, but see [this example][parse5-adapter] which shows how to connect the [parse5][parse5] HTML parser.
+-   No HTML parsing / serialization, but see [this example][parse5-example] which shows how to connect the [parse5][parse5] HTML parser.
 -   No special treatment of HTML documents, including `HTMLElement` and its subclasses. This also includes HTML casing behavior for attributes and tagNames, as well as the `id` / `className` / `classList` properties on `Element` and `compatMode` / `contentType` on `Document`.
 -   No events, no `createEvent` on `Document`.
 -   No support for shadow DOM, `Slotable` / `ShadowRoot`, no `slot` / `attachShadow` / `shadowRoot` on `Element`.
@@ -78,7 +78,7 @@ The following features have not yet been implemented:
 
 [slimdom-sax-parser]: https://github.com/wvbe/slimdom-sax-parser
 [fontoxpath]: https://github.com/FontoXML/fontoxpath/
-[parse5-adapter]: https://github.com/bwrrp/slimdom.js/blob/jest-web-platform-tests/test/web-platform-tests/SlimdomTreeAdapter.ts
+[parse5-example]: https://github.com/bwrrp/slimdom.js/tree/master/test/example/parse5
 [parse5]: https://github.com/inikulin/parse5
 
 Do not rely on the behavior or presence of any methods and properties not specified in the DOM standard. For example, do not use JavaScript array methods exposed on properties that should expose a NodeList and do not use Element as a constructor. This behavior is _not_ considered public API and may change without warning in a future release.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
 	},
 	"devDependencies": {
 		"@types/jest": "^23.3.1",
+		"@types/parse5": "^5.0.0",
 		"jest": "^23.5.0",
+		"parse5": "^5.1.0",
 		"prettier": "^1.14.2",
 		"rimraf": "^2.6.2",
 		"rollup": "^0.65.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,9 @@ export { default as MutationRecord } from './mutation-observer/MutationRecord';
 // Standard DOM does not expose a way to serialize arbitrary nodes as well-formed XML
 export { serializeToWellFormedString } from './dom-parsing/XMLSerializer';
 
+// Unsafe exports, required for connecting a HTML parser
+export { unsafeCreateAttribute, unsafeCreateElement, unsafeAppendAttribute } from './unsafe';
+
 // To avoid cyclic dependencies and enable multiple contexts with their own constructors later,
 // inject all constructors as well as the global document into the default context (i.e., global
 // object) here.

--- a/src/unsafe.ts
+++ b/src/unsafe.ts
@@ -1,0 +1,25 @@
+import Attr from './Attr';
+import Element from './Element';
+
+/**
+ * Create an Attr node without the usual validation of the given names.
+ *
+ * @param namespace
+ * @param prefix
+ * @param localName
+ * @param value
+ * @param element
+ */
+export function unsafeCreateAttribute(
+	namespace: string | null,
+	prefix: string | null,
+	localName: string,
+	value: string,
+	ownerElement: Element | null
+): Attr {
+	return new Attr(namespace, prefix, localName, value, ownerElement);
+}
+
+export { createElement as unsafeCreateElement } from './Element';
+
+export { appendAttribute as unsafeAppendAttribute } from './util/attrMutations';

--- a/test/examples/parse5/SlimdomTreeAdapter.ts
+++ b/test/examples/parse5/SlimdomTreeAdapter.ts
@@ -1,0 +1,217 @@
+import * as parse5 from 'parse5';
+import * as slimdom from '../../../src/index';
+
+function undefinedAsNull<T>(value: T | undefined): T | null {
+	return value === undefined ? null : value;
+}
+
+export default class SlimdomTreeAdapter implements parse5.AST.TreeAdapter {
+	private _globalDocument = new slimdom.Document();
+	private _mode: parse5.AST.DocumentMode = 'no-quirks';
+
+	createDocument(): parse5.AST.Document {
+		return this._globalDocument.implementation.createDocument(null, '');
+	}
+
+	createDocumentFragment(): parse5.AST.DocumentFragment {
+		throw new Error('Method not implemented.');
+	}
+
+	createElement(
+		tagName: string,
+		namespaceURI: string,
+		attrs: parse5.AST.Default.Attribute[]
+	): parse5.AST.Element {
+		const [localName, prefix] =
+			tagName.indexOf(':') >= 0 ? tagName.split(':') : [tagName, null];
+		// Create element without validation, as per HTML parser spec
+		const element = slimdom.unsafeCreateElement(
+			this._globalDocument,
+			localName!,
+			namespaceURI,
+			prefix
+		);
+		attrs.forEach(attr => {
+			// Create and append Attr node without validation, as per HTML parser spec
+			const attribute = slimdom.unsafeCreateAttribute(
+				undefinedAsNull(attr.namespace),
+				undefinedAsNull(attr.prefix),
+				attr.name,
+				attr.value,
+				element
+			);
+			attribute.ownerDocument = this._globalDocument;
+			slimdom.unsafeAppendAttribute(attribute, element);
+		});
+		return element;
+	}
+
+	createCommentNode(data: string): parse5.AST.CommentNode {
+		return this._globalDocument.createComment(data);
+	}
+
+	appendChild(parentNode: parse5.AST.ParentNode, newNode: parse5.AST.Node): void {
+		(parentNode as slimdom.Node).appendChild(newNode as slimdom.Node);
+	}
+
+	insertBefore(
+		parentNode: parse5.AST.ParentNode,
+		newNode: parse5.AST.Node,
+		referenceNode: parse5.AST.Node
+	): void {
+		(parentNode as slimdom.Node).insertBefore(
+			newNode as slimdom.Node,
+			referenceNode as slimdom.Node
+		);
+	}
+
+	setTemplateContent(
+		templateElement: parse5.AST.Element,
+		contentElement: parse5.AST.DocumentFragment
+	): void {
+		throw new Error('Method not implemented.');
+	}
+
+	getTemplateContent(templateElement: parse5.AST.Element): parse5.AST.DocumentFragment {
+		throw new Error('Method not implemented.');
+	}
+
+	setDocumentType(
+		document: parse5.AST.Document,
+		name: string,
+		publicId: string,
+		systemId: string
+	): void {
+		const doctype = this._globalDocument.implementation.createDocumentType(
+			name,
+			publicId,
+			systemId
+		);
+		const doc = document as slimdom.Document;
+		if (doc.doctype) {
+			doc.replaceChild(doctype, doc.doctype);
+		} else {
+			doc.insertBefore(doctype, doc.documentElement);
+		}
+	}
+
+	setDocumentMode(document: parse5.AST.Document, mode: parse5.AST.DocumentMode): void {
+		this._mode = mode;
+	}
+
+	getDocumentMode(document: parse5.AST.Document): parse5.AST.DocumentMode {
+		return this._mode;
+	}
+
+	detachNode(node: parse5.AST.Node): void {
+		const parent = (node as slimdom.Node).parentNode;
+		if (parent) {
+			parent.removeChild(node as slimdom.Node);
+		}
+	}
+
+	insertText(parentNode: parse5.AST.ParentNode, text: string): void {
+		const lastChild = (parentNode as slimdom.Node).lastChild;
+		if (lastChild && lastChild.nodeType === slimdom.Node.TEXT_NODE) {
+			(lastChild as slimdom.Text).appendData(text);
+			return;
+		}
+
+		(parentNode as slimdom.Node).appendChild(this._globalDocument.createTextNode(text));
+	}
+
+	insertTextBefore(
+		parentNode: parse5.AST.ParentNode,
+		text: string,
+		referenceNode: parse5.AST.Node
+	): void {
+		const sibling = referenceNode && (referenceNode as slimdom.Node).previousSibling;
+		if (sibling && sibling.nodeType === slimdom.Node.TEXT_NODE) {
+			(sibling as slimdom.Text).appendData(text);
+			return;
+		}
+
+		(parentNode as slimdom.Node).insertBefore(
+			this._globalDocument.createTextNode(text),
+			referenceNode as slimdom.Node
+		);
+	}
+
+	adoptAttributes(recipient: parse5.AST.Element, attrs: parse5.AST.Default.Attribute[]): void {
+		const element = recipient as slimdom.Element;
+		attrs.forEach(attr => {
+			if (!element.hasAttributeNS(undefinedAsNull(attr.namespace), attr.name)) {
+				element.setAttributeNS(
+					undefinedAsNull(attr.namespace),
+					attr.prefix ? `${attr.prefix}:${attr.name}` : name,
+					attr.value
+				);
+			}
+		});
+	}
+
+	getFirstChild(node: parse5.AST.ParentNode): parse5.AST.Node {
+		return (node as slimdom.Node).firstChild!;
+	}
+
+	getChildNodes(node: parse5.AST.ParentNode): parse5.AST.Node[] {
+		return (node as slimdom.Node).childNodes;
+	}
+
+	getParentNode(node: parse5.AST.Node): parse5.AST.ParentNode {
+		return (node as slimdom.Node).parentNode!;
+	}
+
+	getAttrList(element: parse5.AST.Element): parse5.AST.Default.Attribute[] {
+		return (element as slimdom.Element).attributes.map(attr => ({
+			name: attr.localName,
+			namespace: attr.namespaceURI || undefined,
+			prefix: attr.prefix || undefined,
+			value: attr.value
+		}));
+	}
+
+	getTagName(element: parse5.AST.Element): string {
+		return (element as slimdom.Element).tagName;
+	}
+
+	getNamespaceURI(element: parse5.AST.Element): string {
+		return (element as slimdom.Element).namespaceURI!;
+	}
+
+	getTextNodeContent(textNode: parse5.AST.TextNode): string {
+		return (textNode as slimdom.Text).data;
+	}
+
+	getCommentNodeContent(commentNode: parse5.AST.CommentNode): string {
+		return (commentNode as slimdom.Comment).data;
+	}
+
+	getDocumentTypeNodeName(doctypeNode: parse5.AST.DocumentType): string {
+		return (doctypeNode as slimdom.DocumentType).name;
+	}
+
+	getDocumentTypeNodePublicId(doctypeNode: parse5.AST.DocumentType): string {
+		return (doctypeNode as slimdom.DocumentType).publicId;
+	}
+
+	getDocumentTypeNodeSystemId(doctypeNode: parse5.AST.DocumentType): string {
+		return (doctypeNode as slimdom.DocumentType).systemId;
+	}
+
+	isTextNode(node: parse5.AST.Node): boolean {
+		return node && (node as slimdom.Node).nodeType === slimdom.Node.TEXT_NODE;
+	}
+
+	isCommentNode(node: parse5.AST.Node): boolean {
+		return node && (node as slimdom.Node).nodeType === slimdom.Node.COMMENT_NODE;
+	}
+
+	isDocumentTypeNode(node: parse5.AST.Node): boolean {
+		return node && (node as slimdom.Node).nodeType === slimdom.Node.DOCUMENT_TYPE_NODE;
+	}
+
+	isElementNode(node: parse5.AST.Node): boolean {
+		return node && (node as slimdom.Node).nodeType === slimdom.Node.ELEMENT_NODE;
+	}
+}

--- a/test/examples/parse5/parse5.tests.ts
+++ b/test/examples/parse5/parse5.tests.ts
@@ -1,0 +1,33 @@
+import * as parse5 from 'parse5';
+import * as slimdom from '../../../src/index';
+import SlimdomTreeAdapter from './SlimdomTreeAdapter';
+
+function parseHTML(html: string): slimdom.Document {
+	return parse5.parse(html, { treeAdapter: new SlimdomTreeAdapter() }) as slimdom.Document;
+}
+
+describe('Example: parse5 integration', () => {
+	it('Can parse an HTML file', () => {
+		const doc = parseHTML(`
+<!DOCTYPE html>
+<html>
+<body>
+	<h1>My First Heading</h1>
+	<p class="test">My first paragraph.<br>With multiple lines.</p>
+</body>
+</html>`);
+
+		expect(doc.doctype!.name).toBe('html');
+		expect(doc.documentElement!.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
+		expect(doc.documentElement!.localName).toBe('html');
+
+		// HTML parsers treat whitespace a bit differently
+		expect(slimdom.serializeToWellFormedString(doc)).toBe(
+			`<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml"><head></head><body>
+	<h1>My First Heading</h1>
+	<p class="test">My first paragraph.<br />With multiple lines.</p>
+
+</body></html>`
+		);
+	});
+});


### PR DESCRIPTION
HTML parsing requires the ability to create elements and attributes
without validating the given names. This adds unsafe functions to expose
this functionality, as well as an example integration using parse5.

Fixes #31