### PR TITLE
Use actual microtask and fix cycles

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,17 +30,17 @@
 		"url": "git://github.com/bwrrp/slimdom.js.git"
 	},
 	"devDependencies": {
-		"@types/jest": "^23.3.2",
+		"@types/jest": "^23.3.5",
 		"@types/parse5": "^5.0.0",
 		"jest": "^23.6.0",
 		"parse5": "^5.1.0",
 		"prettier": "^1.14.3",
 		"rimraf": "^2.6.2",
-		"rollup": "^0.66.2",
-		"rollup-plugin-babel-minify": "^6.0.0",
-		"ts-jest": "23.10.1",
+		"rollup": "^0.66.5",
+		"rollup-plugin-babel-minify": "^6.1.1",
+		"ts-jest": "~23.10.4",
 		"typedoc": "^0.12.0",
-		"typescript": "^3.0.3"
+		"typescript": "^3.1.2"
 	},
 	"jest": {
 		"transform": {

--- a/src/CharacterData.ts
+++ b/src/CharacterData.ts
@@ -7,7 +7,7 @@ import {
 import Document from './Document';
 import Element from './Element';
 import Node from './Node';
-import { ranges } from './Range';
+import { getContext } from './context/Context';
 import queueMutationRecord from './mutation-observer/queueMutationRecord';
 import { expectArity, throwIndexSizeError } from './util/errorHelpers';
 import { asNullableString, asUnsignedLong, treatNullAsEmptyString } from './util/typeHelpers';
@@ -213,7 +213,8 @@ export function replaceData(
 	const newData = nodeData.substring(0, offset) + data + nodeData.substring(offset + count);
 	(node as any)._data = newData;
 
-	ranges.forEach(range => {
+	const context = getContext(node);
+	context._ranges.forEach(range => {
 		// 8. For each live range whose start node is node and start offset is greater than offset
 		// but less than or equal to offset plus count, set its start offset to offset.
 		if (

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -1,7 +1,7 @@
 import Element from './Element';
 import Document from './Document';
 import Text from './Text';
-import { ranges } from './Range';
+import { getContext } from './context/Context';
 import RegisteredObservers from './mutation-observer/RegisteredObservers';
 import cloneNode from './util/cloneNode';
 import { expectArity } from './util/errorHelpers';
@@ -160,11 +160,12 @@ export default abstract class Node {
 
 			// 5. Let currentNode be node’s next sibling.
 			// 6. While currentNode is an exclusive Text node:
+			const context = getContext(this);
 			for (let i = 0, l = siblingsToRemove.length; i < l; ++i) {
 				const currentNode = siblingsToRemove[i];
 				const currentNodeIndex = index + i + 1;
 
-				ranges.forEach(range => {
+				context._ranges.forEach(range => {
 					// 6.1. For each live range whose start node is currentNode, add length to its
 					// start offset and set its start node to node.
 					if (range.startContainer === currentNode) {

--- a/src/Range.ts
+++ b/src/Range.ts
@@ -18,8 +18,6 @@ import {
 } from './util/treeHelpers';
 import { asObject, asUnsignedLong } from './util/typeHelpers';
 
-export const ranges: Range[] = [];
-
 /**
  * Interface AbstractRange
  *
@@ -94,7 +92,7 @@ export default class Range implements AbstractRange {
 		this.startOffset = 0;
 		this.endContainer = context.document;
 		this.endOffset = 0;
-		ranges.push(this);
+		context._ranges.push(this);
 	}
 
 	/**
@@ -445,9 +443,10 @@ export default class Range implements AbstractRange {
 	 * the range.
 	 */
 	detach(): void {
-		const index = ranges.indexOf(this);
+		const context = getContext(this);
+		const index = context._ranges.indexOf(this);
 		if (index >= 0) {
-			ranges.splice(index, 1);
+			context._ranges.splice(index, 1);
 		}
 	}
 

--- a/src/Text.ts
+++ b/src/Text.ts
@@ -1,6 +1,5 @@
 import { replaceData, substringData, default as CharacterData } from './CharacterData';
 import Document from './Document';
-import { ranges } from './Range';
 import { getContext } from './context/Context';
 import { expectArity, throwIndexSizeError } from './util/errorHelpers';
 import { insertNode } from './util/mutationAlgorithms';
@@ -106,7 +105,8 @@ function splitText(node: Text, offset: number): Text {
 		insertNode(newNode, parent, node.nextSibling);
 
 		const indexOfNodePlusOne = getNodeIndex(node) + 1;
-		ranges.forEach(range => {
+		const context = getContext(node);
+		context._ranges.forEach(range => {
 			// 7.2. For each live range whose start node is node and start offset is greater than
 			// offset, set its start node to new node and decrease its start offset by offset.
 			if (range.startContainer === node && range.startOffset > offset) {

--- a/src/context/Context.ts
+++ b/src/context/Context.ts
@@ -12,6 +12,7 @@ import Range from '../Range';
 import Text from '../Text';
 import XMLDocument from '../XMLDocument';
 
+import NotifyList from '../mutation-observer/NotifyList';
 import { NodeType } from '../util/NodeType';
 
 export type AttrConstructor = new (
@@ -46,6 +47,7 @@ export type XMLDocumentConstructor = new () => XMLDocument;
 
 export interface Context {
 	document: Document;
+	_notifyList: NotifyList;
 
 	Attr: AttrConstructor;
 	CDATASection: CDATASectionConstructor;
@@ -68,6 +70,14 @@ export interface Context {
  */
 export class DefaultContext implements Context {
 	public document!: Document;
+
+	/**
+	 * The NotifyList instance is shared between all MutationObserver objects. It holds references
+	 * to all MutationObserver instances that have collected records, and is responsible for
+	 * invoking their callbacks when control returns to the event loop (using setImmediate or
+	 * setTimeout).
+	 */
+	public _notifyList: NotifyList = new NotifyList();
 
 	public Attr!: AttrConstructor;
 	public CDATASection!: CDATASectionConstructor;

--- a/src/context/Context.ts
+++ b/src/context/Context.ts
@@ -47,7 +47,9 @@ export type XMLDocumentConstructor = new () => XMLDocument;
 
 export interface Context {
 	document: Document;
+
 	_notifyList: NotifyList;
+	_ranges: Range[];
 
 	Attr: AttrConstructor;
 	CDATASection: CDATASectionConstructor;
@@ -74,10 +76,10 @@ export class DefaultContext implements Context {
 	/**
 	 * The NotifyList instance is shared between all MutationObserver objects. It holds references
 	 * to all MutationObserver instances that have collected records, and is responsible for
-	 * invoking their callbacks when control returns to the event loop (using setImmediate or
-	 * setTimeout).
+	 * invoking their callbacks when control returns to the event loop.
 	 */
 	public _notifyList: NotifyList = new NotifyList();
+	public _ranges: Range[] = [];
 
 	public Attr!: AttrConstructor;
 	public CDATASection!: CDATASectionConstructor;

--- a/src/mutation-observer/MutationObserver.ts
+++ b/src/mutation-observer/MutationObserver.ts
@@ -46,14 +46,6 @@ export type MutationCallback = (records: MutationRecord[], observer: MutationObs
  */
 export default class MutationObserver {
 	/**
-	 * The NotifyList instance is shared between all MutationObserver objects. It holds references
-	 * to all MutationObserver instances that have collected records, and is responsible for
-	 * invoking their callbacks when control returns to the event loop (using setImmediate or
-	 * setTimeout).
-	 */
-	static _notifyList = new NotifyList();
-
-	/**
 	 * The function that will be called when control returns to the event loop, if there are any
 	 * queued records. The function is passed the MutationRecords and the observer instance that
 	 * collected them.

--- a/src/mutation-observer/queueMutationRecord.ts
+++ b/src/mutation-observer/queueMutationRecord.ts
@@ -1,3 +1,4 @@
+import { getContext } from '../context/Context';
 import MutationObserver from './MutationObserver';
 import { MutationRecordInit, default as MutationRecord } from './MutationRecord';
 import Node from '../Node';
@@ -37,6 +38,8 @@ export default function queueMutationRecord(type: string, target: Node, data: Mu
 			pairedStrings
 		);
 	}
+
+	const context = getContext(target);
 
 	// 4. For each observer → mappedOldValue of interestedObservers:
 	interestedObservers.forEach((observer, index) => {
@@ -78,9 +81,9 @@ export default function queueMutationRecord(type: string, target: Node, data: Mu
 		}
 
 		// 4.2. Enqueue record to observer’s record queue.
-		MutationObserver._notifyList.appendRecord(observer, record);
+		context._notifyList.appendRecord(observer, record);
 	});
 
 	// 5. Queue a mutation observer compound microtask.
-	MutationObserver._notifyList.queueMutationObserverCompoundMicrotask();
+	context._notifyList.queueMutationObserverCompoundMicrotask();
 }

--- a/src/util/mutationAlgorithms.ts
+++ b/src/util/mutationAlgorithms.ts
@@ -11,7 +11,7 @@ import Document from '../Document';
 import DocumentFragment from '../DocumentFragment';
 import Element from '../Element';
 import Node from '../Node';
-import { ranges } from '../Range';
+import { getContext } from '../context/Context';
 import queueMutationRecord from '../mutation-observer/queueMutationRecord';
 
 // 3.2.3. Mutation algorithms
@@ -210,7 +210,8 @@ export function insertNode(
 	// 2. If child is non-null, then:
 	if (child !== null) {
 		const childIndex = getNodeIndex(child);
-		ranges.forEach(range => {
+		const context = getContext(node);
+		context._ranges.forEach(range => {
 			// 2.1. For each live range whose start node is parent and start offset is greater than
 			// child’s index, increase its start offset by count.
 			if (range.startContainer === parent && range.startOffset > childIndex) {
@@ -525,7 +526,8 @@ export function removeNode(node: Node, parent: Node, suppressObservers: boolean 
 	// 1. Let index be node’s index.
 	const index = getNodeIndex(node);
 
-	ranges.forEach(range => {
+	const context = getContext(node);
+	context._ranges.forEach(range => {
 		// 2. For each live range whose start node is an inclusive descendant of node, set its start
 		// to (parent, index).
 		if (node.contains(range.startContainer)) {


### PR DESCRIPTION
Before, if mutation observer callbacks needed to run asynchronously, they were scheduled using either setImmediate or setTimeout (depending on availability). This could allow other tasks to run before the callback, which could be unexpected. This changes the scheduling to use an actual microtask, courtesy of Promise#then.

The only negative I can see here is that errors thrown from the callback will now appear as unhandled rejections rather than plain unhandled errors. I'd love a plain requestMicrotask API to solve this, but can't see a better way at this time...

This PR also includes two other commits that remove circular dependencies by moving two pieces of global state (the NotifyList instance and the array of live Ranges) to the Context object, which is meant to hold such state anyway.