### PR TITLE
Use non-capturing groups in the regexes

### DIFF
--- a/src/dom-parsing/serializationAlgorithms.ts
+++ b/src/dom-parsing/serializationAlgorithms.ts
@@ -35,7 +35,7 @@ const Char = regenerate()
 
 return `^(${Char.toString()})*$`;
 */
-const CHAR_REGEX_XML_1_0_FIFTH_EDITION = /^([\t\n\r -\uD7FF\uE000-\uFFFD]|[\uD800-\uDB7F][\uDC00-\uDFFF])*$/;
+const CHAR_REGEX_XML_1_0_FIFTH_EDITION = /^(?:[\t\n\r -\uD7FF\uE000-\uFFFD]|[\uD800-\uDB7F][\uDC00-\uDFFF])*$/;
 
 /*
 // PUBIDCHAR_REGEX_XML_1_0_FIFTH_EDITION generated using regenerate:
@@ -53,7 +53,7 @@ const PubidChar = regenerate()
 
 `^(${PubidChar.toString()})*$`;
 */
-const PUBIDCHAR_REGEX_XML_1_0_FIFTH_EDITION = /^([\n\r !#-%'-;=\?-Z_a-z])*$/;
+const PUBIDCHAR_REGEX_XML_1_0_FIFTH_EDITION = /^(?:[\n\r !#-%'-;=\?-Z_a-z])*$/;
 
 const HTML_VOID_ELEMENTS = [
 	'area',

--- a/test/dom-parsing/XMLSerializer.tests.ts
+++ b/test/dom-parsing/XMLSerializer.tests.ts
@@ -439,4 +439,15 @@ describe('serializeToWellFormedString', () => {
 	it('can serialize normally if there are no well-formedness violations', () => {
 		expect(slimdom.serializeToWellFormedString(document.createElement('el'))).toBe('<el/>');
 	});
+
+	it('can serialize a very large amount of data', () => {
+		const data = Array.from({ length: 10_000_000 })
+			.map(_ => '&')
+			.join('');
+		const el = document.createElement('meep');
+		el.appendChild(document.createTextNode(data));
+		expect(() => {
+			slimdom.serializeToWellFormedString(el);
+		}).not.toThrow();
+	});
 });


### PR DESCRIPTION
Having these groups be capturing results in stack overflow errors in
.test when run on very large strings (i.e., several megabytes of text).

Fixes #87