### PR TITLE
Allow resetting the default namespace on prefixed elements

### DIFF
--- a/src/dom-parsing/serializationAlgorithms.ts
+++ b/src/dom-parsing/serializationAlgorithms.ts
@@ -747,7 +747,10 @@ function serializeAttributes(
 				// value of attr's value attribute is the empty string, then throw an exception;
 				// namespace prefix declarations cannot be used to undeclare a namespace (use a
 				// default namespace declaration instead).
-				if (requireWellFormed && attr.value === '') {
+				// (we deviate from the spec here by only throwing for prefix declarations, the
+				// implementations of this in browsers and the spec text suggest that default
+				// namespace declarations should be allowed to reset the default namespace to null)
+				if (requireWellFormed && attr.prefix !== null && attr.value === '') {
 					throw new Error(
 						'Namespace prefix declarations cannot be used to undeclare a namespace ' +
 							'(use a default namespace declaration instead)'

--- a/test/dom-parsing/XMLSerializer.tests.ts
+++ b/test/dom-parsing/XMLSerializer.tests.ts
@@ -450,4 +450,23 @@ describe('serializeToWellFormedString', () => {
 			slimdom.serializeToWellFormedString(el);
 		}).not.toThrow();
 	});
+
+	it('allows resetting the default namespace', () => {
+		const root = document.appendChild(document.createElementNS('ns_root', 'root'));
+		const child = root.appendChild(document.createElementNS('ns_child', 'p:child'));
+		const grandChild = child.appendChild(document.createElementNS(null, 'grandchild'));
+		expect(slimdom.serializeToWellFormedString(document)).toBe(
+			'<root xmlns="ns_root"><p:child xmlns:p="ns_child"><grandchild xmlns=""/></p:child></root>'
+		);
+	});
+
+	it('allows resetting the default namespace using an explicit declaration', () => {
+		const root = document.appendChild(document.createElementNS('ns_root', 'root'));
+		const child = root.appendChild(document.createElementNS('ns_child', 'p:child'));
+		child.setAttributeNS(XMLNS_NAMESPACE, 'xmlns', '');
+		const grandChild = child.appendChild(document.createElementNS(null, 'grandchild'));
+		expect(slimdom.serializeToWellFormedString(document)).toBe(
+			'<root xmlns="ns_root"><p:child xmlns:p="ns_child" xmlns=""><grandchild/></p:child></root>'
+		);
+	});
 });


### PR DESCRIPTION
This fixes #86, which seems to be caused by a potential bug in the specification (filed as w3c/DOM-Parsing#48). Resetting the default namespace manually on an element that is not itself in that namespace seems like a valid use case. Testing in Firefox and Chrome does not result in an error being thrown. Let's follow their example here rather than the spec text.
