### PR TITLE
Implement non-HTML-specific Document query methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ This library does not implement CSS selectors, which means no `querySelector` / 
 
 To query a slimdom document using XPath or XQuery, use [FontoXPath][fontoxpath].
 
+To query a slimdom document using CSS, see [this example][sizzle-example] which shows how to use [sizzle][sizzle] to run queries using CSS selectors.
+
 ### HTML & browser-specific features and behavior
 
 Emulating a full browser environment is not the goal of this library. Consider using [jsdom][jsdom] instead if you need that.
@@ -100,6 +102,8 @@ The following features are missing simply because I have not yet had a need for 
 [parse5-example]: https://github.com/bwrrp/slimdom.js/tree/main/test/examples/parse5
 [parse5]: https://github.com/inikulin/parse5
 [dom-treeadapter]: https://github.com/RReverser/dom-treeadapter
+[sizzle-example]: https://github.com/bwrrp/slimdom.js/tree/master/test/examples/sizzle
+[sizzle]: https://github.com/jquery/sizzle
 [jsdom]: https://github.com/jsdom/jsdom
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ This library omits properties and methods that exist mainly for web compatibilit
 
 The following features are missing simply because I have not yet had a need for them. If you do need one, feel free to create a feature request issue or even submit a pull request.
 
--   Older non-CSS, non-HTML query methods (`getElementsByTagName` / `getElementsByTagNameNS` on `Document`).
 -   Iteration helpers (`NodeIterator` / `TreeWalker` / `NodeFilter`, and the `createNodeIterator` / `createTreeWalker` methods on `Document`).
 -   DOM-modifying methods on Range (`deleteContents` / `extractContents` / `cloneContents` / `insertNode` / `surroundContents`).
 -   `attributeFilter` for mutation observers.

--- a/api/slimdom.api.json
+++ b/api/slimdom.api.json
@@ -2620,6 +2620,121 @@
               "isStatic": false
             },
             {
+              "kind": "Method",
+              "canonicalReference": "slimdom!Document#getElementsByTagName:member(1)",
+              "docComment": "/**\n * Returns the list of elements with the given qualified name.\n *\n * @param qualifiedName - Qualified name of the elements to collect.\n *\n * @returns The list of elements with matching qualified name.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getElementsByTagName(qualifiedName: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Element",
+                  "canonicalReference": "slimdom!default:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isOptional": false,
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 5
+              },
+              "releaseTag": "Public",
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "qualifiedName",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  }
+                }
+              ],
+              "name": "getElementsByTagName"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "slimdom!Document#getElementsByTagNameNS:member(1)",
+              "docComment": "/**\n * Returns the list of elements with the given namespace and local name.\n *\n * @param namespace - Namespace URI of the elements to collect.\n *\n * @param localName - Local name of the elements to collect\n *\n * @returns The list of elements with matching namespace and local name.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getElementsByTagNameNS(namespace: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string | null"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", localName: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Element",
+                  "canonicalReference": "slimdom!default:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isOptional": false,
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 5,
+                "endIndex": 7
+              },
+              "releaseTag": "Public",
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "namespace",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  }
+                },
+                {
+                  "parameterName": "localName",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 3,
+                    "endIndex": 4
+                  }
+                }
+              ],
+              "name": "getElementsByTagNameNS"
+            },
+            {
               "kind": "Property",
               "canonicalReference": "slimdom!Document#implementation:member",
               "docComment": "/**\n * Returns a reference to the DOMImplementation object associated with the document.\n */\n",

--- a/api/slimdom.api.md
+++ b/api/slimdom.api.md
@@ -126,6 +126,8 @@ export class Document extends Node implements NonElementParentNode, ParentNode {
     documentElement: Element | null;
     // (undocumented)
     firstElementChild: Element | null;
+    getElementsByTagName(qualifiedName: string): Element[];
+    getElementsByTagNameNS(namespace: string | null, localName: string): Element[];
     readonly implementation: DOMImplementation;
     importNode<TNode extends Node>(node: TNode, deep?: boolean): TNode;
     // (undocumented)

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"rollup": "^2.38.1",
 		"rollup-plugin-sourcemaps": "^0.6.3",
 		"rollup-plugin-terser": "^7.0.2",
+		"sizzle": "^2.3.5",
 		"ts-jest": "~26.5.0",
 		"typescript": "^4.1.3"
 	},

--- a/src/Document.ts
+++ b/src/Document.ts
@@ -22,6 +22,7 @@ import { adoptNode, appendNodes, prependNodes } from './util/mutationAlgorithms'
 import { NodeType, isNodeOfType } from './util/NodeType';
 import { matchesNameProduction, validateAndExtract } from './util/namespaceHelpers';
 import { asNullableString, asObject } from './util/typeHelpers';
+import { forEachInclusiveDescendant } from './util/treeHelpers';
 
 /**
  * 3.5. Interface Document
@@ -132,6 +133,92 @@ export default class Document extends Node implements NonElementParentNode, Pare
 	 */
 	constructor() {
 		super();
+	}
+
+	/**
+	 * Returns the list of elements with the given qualified name.
+	 *
+	 * @param qualifiedName - Qualified name of the elements to collect.
+	 *
+	 * @returns  The list of elements with matching qualified name.
+	 */
+	public getElementsByTagName(qualifiedName: string): Element[] {
+		expectArity(arguments, 1);
+		qualifiedName = String(qualifiedName);
+
+		const elements: Element[] = [];
+		forEachInclusiveDescendant(this, (node) => {
+			if (node.nodeType !== NodeType.ELEMENT_NODE) {
+				return;
+			}
+			const element = node as Element;
+
+			if (
+				// 1. If qualifiedName is "*" (U+002A), return a HTMLCollection rooted at root,
+				//    whose filter matches only descendant elements.
+				qualifiedName === '\u002a' ||
+				// 2. Otherwise, if root’s node document is an HTML document,
+				//    return a HTMLCollection rooted at root, whose filter matches the following
+				//    descendant elements:
+				//    - Whose namespace is the HTML namespace and whose qualified name is qualifiedName,
+				//      in ASCII lowercase.
+				//    - Whose namespace is not the HTML namespace and whose qualified name is
+				//      qualifiedName.
+				// (html documents not implemented)
+
+				// 3. Otherwise, return a HTMLCollection rooted at root, whose filter matches
+				//    descendant elements whose qualified name is qualifiedName.
+				element.nodeName === qualifiedName
+			) {
+				elements.push(element);
+			}
+		});
+
+		return elements;
+	}
+
+	/**
+	 * Returns the list of elements with the given namespace and local name.
+	 *
+	 * @param namespace - Namespace URI of the elements to collect.
+	 * @param localName - Local name of the elements to collect
+	 *
+	 * @returns  The list of elements with matching namespace and local name.
+	 */
+	public getElementsByTagNameNS(namespace: string | null, localName: string): Element[] {
+		expectArity(arguments, 2);
+		namespace = asNullableString(namespace);
+		localName = String(localName);
+
+		// 1. If namespace is the empty string, set it to null.
+		if (namespace === '') {
+			namespace = null;
+		}
+
+		const elements: Element[] = [];
+		forEachInclusiveDescendant(this, (node) => {
+			if (node.nodeType !== NodeType.ELEMENT_NODE) {
+				return;
+			}
+			const element = node as Element;
+
+			if (
+				// 2. If both namespace and localName are "*" (U+002A), return a HTMLCollection
+				//    rooted at root, whose filter matches descendant elements.
+				// 3. Otherwise, if namespace is "*" (U+002A), return a HTMLCollection rooted at
+				//    root, whose filter matches descendant elements whose local name is localName.
+				// 4. Otherwise, if localName is "*" (U+002A), return a HTMLCollection rooted at
+				//    root, whose filter matches descendant elements whose namespace is namespace.
+				// 5. Otherwise, return a HTMLCollection rooted at root, whose filter matches
+				//    descendant elements whose namespace is namespace and local name is localName.
+				(namespace === '\u002a' || element.namespaceURI === namespace) &&
+				(localName === '\u002a' || element.localName === localName)
+			) {
+				elements.push(element);
+			}
+		});
+
+		return elements;
 	}
 
 	/**

--- a/test/Document.tests.ts
+++ b/test/Document.tests.ts
@@ -119,6 +119,107 @@ describe('Document', () => {
 		});
 	});
 
+	describe('.getElementsByTagName', () => {
+		it('can find all descendants matching the given qualifiedName', () => {
+			const root = document.appendChild(document.createElement('root'));
+			const e1 = root.appendChild(document.createElementNS('namespace', 'pre:elem'));
+			const e2 = root.appendChild(document.createElementNS('namespace', 'pre:elem'));
+			const other = root.appendChild(document.createElementNS(null, 'other'));
+			const e3 = other.appendChild(document.createElementNS('otherns', 'pre:elem'));
+			const e4 = other.appendChild(document.createElementNS('otherns', 'pre:elem'));
+			const e5 = other.appendChild(document.createElementNS('otherns', 'x:elem'));
+			const e6 = other.appendChild(document.createElementNS('otherns', 'x:elem'));
+
+			expect(document.getElementsByTagName('root')).toEqual([root]);
+			expect(document.getElementsByTagName('pre:elem')).toEqual([e1, e2, e3, e4]);
+			expect(document.getElementsByTagName('other')).toEqual([other]);
+			expect(document.getElementsByTagName('x:elem')).toEqual([e5, e6]);
+		});
+
+		it('can find all descendant elements using the special name "*"', () => {
+			const root = document.appendChild(document.createElement('root'));
+			const e1 = root.appendChild(document.createElementNS('namespace', 'pre:elem'));
+			const e2 = root.appendChild(document.createElementNS('namespace', 'pre:elem'));
+			const other = root.appendChild(document.createElementNS(null, 'other'));
+			const e3 = other.appendChild(document.createElementNS('otherns', 'pre:elem'));
+			const e4 = other.appendChild(document.createElementNS('otherns', 'pre:elem'));
+			const e5 = other.appendChild(document.createElementNS('otherns', 'x:elem'));
+			const e6 = other.appendChild(document.createElementNS('otherns', 'x:elem'));
+
+			expect(document.getElementsByTagName('*')).toEqual([
+				root,
+				e1,
+				e2,
+				other,
+				e3,
+				e4,
+				e5,
+				e6,
+			]);
+		});
+	});
+
+	describe('.getElementsByTagNameNS', () => {
+		it('can find all descendants matching the given namespace and localName', () => {
+			const root = document.appendChild(document.createElement('root'));
+			const e1 = root.appendChild(document.createElementNS('namespace', 'pre:elem'));
+			const e2 = root.appendChild(document.createElementNS('namespace', 'pre:elem'));
+			const other = root.appendChild(document.createElementNS(null, 'other'));
+			const e3 = other.appendChild(document.createElementNS('otherns', 'pre:elem'));
+			const e4 = other.appendChild(document.createElementNS('otherns', 'pre:elem'));
+			const e5 = other.appendChild(document.createElementNS('otherns', 'x:elem'));
+			const e6 = other.appendChild(document.createElementNS('otherns', 'x:elem'));
+
+			expect(document.getElementsByTagNameNS(null, 'root')).toEqual([root]);
+			expect(document.getElementsByTagNameNS('zoinks', 'root')).toEqual([]);
+			expect(document.getElementsByTagNameNS('namespace', 'elem')).toEqual([e1, e2]);
+			expect(document.getElementsByTagNameNS('otherns', 'elem')).toEqual([e3, e4, e5, e6]);
+			expect(document.getElementsByTagNameNS('', 'other')).toEqual([other]);
+		});
+
+		it('can find all descendant elements using the special namespace "*"', () => {
+			const root = document.appendChild(document.createElement('root'));
+			const e1 = root.appendChild(document.createElementNS('namespace', 'pre:elem'));
+			const e2 = root.appendChild(document.createElementNS('namespace', 'pre:elem'));
+			const other = root.appendChild(document.createElementNS(null, 'other'));
+			const e3 = other.appendChild(document.createElementNS('otherns', 'pre:elem'));
+			const e4 = other.appendChild(document.createElementNS('otherns', 'pre:elem'));
+			const e5 = other.appendChild(document.createElementNS('otherns', 'x:elem'));
+			const e6 = other.appendChild(document.createElementNS('otherns', 'x:elem'));
+
+			expect(document.getElementsByTagNameNS('*', 'root')).toEqual([root]);
+			expect(document.getElementsByTagNameNS('*', 'elem')).toEqual([e1, e2, e3, e4, e5, e6]);
+			expect(document.getElementsByTagNameNS('*', 'other')).toEqual([other]);
+		});
+
+		it('can find all descendant elements using the special localName "*"', () => {
+			const root = document.appendChild(document.createElement('root'));
+			const e1 = root.appendChild(document.createElementNS('namespace', 'pre:elem'));
+			const e2 = root.appendChild(document.createElementNS('namespace', 'pre:elem'));
+			const other = root.appendChild(document.createElementNS(null, 'other'));
+			const e3 = other.appendChild(document.createElementNS('otherns', 'pre:elem'));
+			const e4 = other.appendChild(document.createElementNS('otherns', 'pre:elem'));
+			const e5 = other.appendChild(document.createElementNS('otherns', 'x:elem'));
+			const e6 = other.appendChild(document.createElementNS('otherns', 'x:elem'));
+
+			expect(document.getElementsByTagNameNS(null, '*')).toEqual([root, other]);
+			expect(document.getElementsByTagNameNS('', '*')).toEqual([root, other]);
+			expect(document.getElementsByTagNameNS('zoinks', '*')).toEqual([]);
+			expect(document.getElementsByTagNameNS('namespace', '*')).toEqual([e1, e2]);
+			expect(document.getElementsByTagNameNS('otherns', '*')).toEqual([e3, e4, e5, e6]);
+			expect(document.getElementsByTagNameNS('*', '*')).toEqual([
+				root,
+				e1,
+				e2,
+				other,
+				e3,
+				e4,
+				e5,
+				e6,
+			]);
+		});
+	});
+
 	describe('.cloneNode', () => {
 		beforeEach(() => {
 			document.appendChild(document.createElement('root'));

--- a/test/examples/sizzle/sizzle.d.ts
+++ b/test/examples/sizzle/sizzle.d.ts
@@ -1,0 +1,1 @@
+declare module 'sizzle';

--- a/test/examples/sizzle/sizzle.tests.ts
+++ b/test/examples/sizzle/sizzle.tests.ts
@@ -1,0 +1,23 @@
+import * as slimdom from '../../../src/index';
+
+import Sizzle = require('sizzle');
+
+describe('Example: sizzle integration', () => {
+	it('can use CSS selectors using Sizzle', () => {
+		const document = new slimdom.Document();
+		const root = document.appendChild(document.createElement('root'));
+		const p1 = root.appendChild(document.createElement('p'));
+		const p2 = root.appendChild(document.createElement('p'));
+		const p3 = root.appendChild(document.createElement('p'));
+		const div = root.appendChild(document.createElement('div'));
+		const p4 = div.appendChild(document.createElement('p'));
+		p1.setAttribute('id', 'header');
+		p4.setAttribute('class', 'footer');
+
+		expect(Sizzle('p', document)).toEqual([p1, p2, p3, p4]);
+		expect(Sizzle('div p', document)).toEqual([p4]);
+		expect(Sizzle('p ~ p', document)).toEqual([p2, p3]);
+		expect(Sizzle('#header', document)).toEqual([p1]);
+		expect(Sizzle('.footer', document)).toEqual([p4]);
+	});
+});


### PR DESCRIPTION
And add an example showing how to use jQuery's Sizzle CSS engine, which now works