### PR TITLE
Update to latest specs, add StaticRange and replaceChildren

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Fast, tiny, standards-compliant XML DOM implementation for node and the browser.
 
-This is a (partial) implementation of the [DOM living standard][domstandard], as last updated 1 March 2019, and the [DOM Parsing and Serialization W3C Editor's Draft][domparsing], as last updated 11 February 2019. See the 'Features and Limitations' section below for details on what's included and what's not.
+This is a (partial) implementation of the [DOM living standard][domstandard], as last updated 27 January 2021, and the [DOM Parsing and Serialization W3C Editor's Draft][domparsing], as last updated 20 April 2020. See the 'Features and Limitations' section below for details on what's included and what's not.
 
 [domstandard]: https://dom.spec.whatwg.org/
 [domparsing]: https://w3c.github.io/DOM-Parsing/
@@ -68,7 +68,7 @@ If you need to parse HTML, see [this example][parse5-example] which shows how to
 
 ### CSS Selectors and XPath
 
-This library does not implement CSS selectors, which means no `querySelector` / `querySelectorAll` on `ParentNode` and no `closest` / `matches` / `webkitMatchesSelector` on `Element`.
+This library does not implement CSS selectors, which means no `querySelector` / `querySelectorAll` on `ParentNode` and no `closest` / `matches` / `webkitMatchesSelector` on `Element`. This library also does not implement XPath, which means no `XPathResult` / `XPathExpression` / `XPathEvaluator` interfaces and no `createExpression` / `createNSResolver` / `evaluate` on `Document`.
 
 To query a slimdom document using XPath or XQuery, use [FontoXPath][fontoxpath].
 
@@ -82,11 +82,11 @@ This implementation offers no special treatment of HTML documents, which means t
 
 This library also does not currently implement events, including the `Event` / `EventTarget` interfaces. It also currently does not contain an implementation of `AbortController` / `AbortSignal`. As these may have wider applications than browser-specific use cases, please file an issue if you have a use for these in your application and would like support for them to be added.
 
-There is currently no support for shadow DOM, so no `Slotable` / `ShadowRoot` interfaces and no `slot` / `attachShadow` / `shadowRoot` on `Element`. Slimdom also does not support the APIs for custom elements using the `is` option on `createElement` / `createElementNS`.
+There is currently no support for shadow DOM, so no `Slottable` / `ShadowRoot` interfaces and no `slot` / `attachShadow` / `shadowRoot` on `Element`. Slimdom also does not support the APIs for custom elements using the `is` option on `createElement` / `createElementNS`.
 
-This library has no notion of URLs (`baseURI` on `Node`, and `URL` / `documentURI` / `origin` on `Document`), nor of encodings (`characterSet` / `charset` / `inputEncoding` on `Document`). This library only deals with JavaScript strings, not raw byte streams.
+This library has no notion of URLs (`baseURI` on `Node`, and `URL` / `documentURI` on `Document`), nor of encodings (`characterSet` / `charset` / `inputEncoding` on `Document`). This library only deals with JavaScript strings, not raw byte streams.
 
-This library omits properties and methods that exist mainly for web compatibility reasons (`insertAdjacentElement` / `insertAdjacentText` on `Element`, `hasFeature` on `DOMImplementation`, and `specified` on `Attr`).
+This library omits properties and methods that exist mainly for web compatibility reasons (`insertAdjacentElement` / `insertAdjacentText` on `Element`, `hasFeature` on `DOMImplementation`, and `specified` on `Attr`). This also includes all interfaces and interface members listed as removed in the [DOM living standard][domstandard].
 
 ### Miscellaneous
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ This library omits properties and methods that exist mainly for web compatibilit
 
 The following features are missing simply because I have not yet had a need for them. If you do need one, feel free to create a feature request issue or even submit a pull request.
 
--   Older non-CSS, non-HTML query methods (`getElementsByTagName` / `getElementsByTagNameNS` on `Document`).
 -   Iteration helpers (`NodeIterator` / `TreeWalker` / `NodeFilter`, and the `createNodeIterator` / `createTreeWalker` methods on `Document`).
 -   DOM-modifying methods on Range (`deleteContents` / `extractContents` / `cloneContents` / `insertNode` / `surroundContents`).
 -   `attributeFilter` for mutation observers.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ This library does not implement CSS selectors, which means no `querySelector` / 
 
 To query a slimdom document using XPath or XQuery, use [FontoXPath][fontoxpath].
 
+To query a slimdom document using CSS, see [this example][sizzle-example] which shows how to use [sizzle][sizzle] to run queries using CSS selectors.
+
 ### HTML & browser-specific features and behavior
 
 Emulating a full browser environment is not the goal of this library. Consider using [jsdom][jsdom] instead if you need that.
@@ -100,6 +102,8 @@ The following features are missing simply because I have not yet had a need for 
 [parse5-example]: https://github.com/bwrrp/slimdom.js/tree/master/test/examples/parse5
 [parse5]: https://github.com/inikulin/parse5
 [dom-treeadapter]: https://github.com/RReverser/dom-treeadapter
+[sizzle-example]: https://github.com/bwrrp/slimdom.js/tree/master/test/examples/sizzle
+[sizzle]: https://github.com/jquery/sizzle
 [jsdom]: https://github.com/jsdom/jsdom
 
 ## Contributing

--- a/api/slimdom.api.json
+++ b/api/slimdom.api.json
@@ -40,7 +40,7 @@
             {
               "kind": "Method",
               "canonicalReference": "slimdom!Attr#_copy:member(1)",
-              "docComment": "/**\n * (non-standard) Creates a copy of the context object, not including its children.\n *\n * @param document - The node document to associate with the copy\n *\n * @returns A shallow copy of the context object\n */\n",
+              "docComment": "/**\n * (non-standard) Creates a copy of this, not including its children.\n *\n * @param document - The node document to associate with the copy\n *\n * @returns A shallow copy of this\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -588,7 +588,7 @@
             {
               "kind": "Method",
               "canonicalReference": "slimdom!CDATASection#_copy:member(1)",
-              "docComment": "/**\n * (non-standard) Creates a copy of the context object, not including its children.\n *\n * @param document - The node document to associate with the copy\n *\n * @returns A shallow copy of the context object\n */\n",
+              "docComment": "/**\n * (non-standard) Creates a copy of this, not including its children.\n *\n * @param document - The node document to associate with the copy\n *\n * @returns A shallow copy of this\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -1630,7 +1630,7 @@
             {
               "kind": "Method",
               "canonicalReference": "slimdom!Comment#_copy:member(1)",
-              "docComment": "/**\n * (non-standard) Creates a copy of the context object, not including its children.\n *\n * @param document - The node document to associate with the copy\n *\n * @returns A shallow copy of the context object\n */\n",
+              "docComment": "/**\n * (non-standard) Creates a copy of this, not including its children.\n *\n * @param document - The node document to associate with the copy\n *\n * @returns A shallow copy of this\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -1812,7 +1812,7 @@
             {
               "kind": "Method",
               "canonicalReference": "slimdom!Document#_copy:member(1)",
-              "docComment": "/**\n * (non-standard) Creates a copy of the context object, not including its children.\n *\n * @param document - The node document to associate with the copy\n *\n * @returns A shallow copy of the context object\n */\n",
+              "docComment": "/**\n * (non-standard) Creates a copy of this, not including its children.\n *\n * @param document - The node document to associate with the copy\n *\n * @returns A shallow copy of this\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -2160,7 +2160,7 @@
             {
               "kind": "Method",
               "canonicalReference": "slimdom!Document#createCDATASection:member(1)",
-              "docComment": "/**\n * Returns a new CDATA section with the given data and node document set to the context object.\n *\n * @param data - Data for the new CDATA section\n *\n * @returns The new CDATA section\n */\n",
+              "docComment": "/**\n * Returns a new CDATA section with the given data and node document set to this.\n *\n * @param data - Data for the new CDATA section\n *\n * @returns The new CDATA section\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -2252,7 +2252,7 @@
             {
               "kind": "Method",
               "canonicalReference": "slimdom!Document#createDocumentFragment:member(1)",
-              "docComment": "/**\n * Returns a new DocumentFragment node with its node document set to the context object.\n *\n * @returns The new document fragment\n */\n",
+              "docComment": "/**\n * Returns a new DocumentFragment node with its node document set to this.\n *\n * @returns The new document fragment\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -2389,7 +2389,7 @@
             {
               "kind": "Method",
               "canonicalReference": "slimdom!Document#createProcessingInstruction:member(1)",
-              "docComment": "/**\n * Creates a new processing instruction node, with target set to target, data set to data, and node document set to the context object.\n *\n * @param target - Target for the new processing instruction\n *\n * @param data - Data for the new processing instruction\n *\n * @returns The new processing instruction\n */\n",
+              "docComment": "/**\n * Creates a new processing instruction node, with target set to target, data set to data, and node document set to this.\n *\n * @param target - Target for the new processing instruction\n *\n * @param data - Data for the new processing instruction\n *\n * @returns The new processing instruction\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -3106,6 +3106,60 @@
               "name": "prepend"
             },
             {
+              "kind": "Method",
+              "canonicalReference": "slimdom!Document#replaceChildren:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "replaceChildren(...nodes: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "("
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Node",
+                  "canonicalReference": "slimdom!default:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | string)[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isOptional": false,
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 5,
+                "endIndex": 6
+              },
+              "releaseTag": "Public",
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "nodes",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 4
+                  }
+                }
+              ],
+              "name": "replaceChildren"
+            },
+            {
               "kind": "Property",
               "canonicalReference": "slimdom!Document#textContent:member",
               "docComment": "",
@@ -3221,7 +3275,7 @@
             {
               "kind": "Method",
               "canonicalReference": "slimdom!DocumentFragment#_copy:member(1)",
-              "docComment": "/**\n * (non-standard) Creates a copy of the context object, not including its children.\n *\n * @param document - The node document to associate with the copy\n *\n * @returns A shallow copy of the context object\n */\n",
+              "docComment": "/**\n * (non-standard) Creates a copy of this, not including its children.\n *\n * @param document - The node document to associate with the copy\n *\n * @returns A shallow copy of this\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -3686,6 +3740,60 @@
               "name": "prepend"
             },
             {
+              "kind": "Method",
+              "canonicalReference": "slimdom!DocumentFragment#replaceChildren:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "replaceChildren(...nodes: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "("
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Node",
+                  "canonicalReference": "slimdom!default:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | string)[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isOptional": false,
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 5,
+                "endIndex": 6
+              },
+              "releaseTag": "Public",
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "nodes",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 4
+                  }
+                }
+              ],
+              "name": "replaceChildren"
+            },
+            {
               "kind": "Property",
               "canonicalReference": "slimdom!DocumentFragment#textContent:member",
               "docComment": "",
@@ -3770,7 +3878,7 @@
             {
               "kind": "Method",
               "canonicalReference": "slimdom!DocumentType#_copy:member(1)",
-              "docComment": "/**\n * (non-standard) Creates a copy of the context object, not including its children.\n *\n * @param document - The node document to associate with the copy\n *\n * @returns A shallow copy of the context object\n */\n",
+              "docComment": "/**\n * (non-standard) Creates a copy of this, not including its children.\n *\n * @param document - The node document to associate with the copy\n *\n * @returns A shallow copy of this\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -6056,6 +6164,60 @@
             },
             {
               "kind": "Method",
+              "canonicalReference": "slimdom!Element#replaceChildren:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "replaceChildren(...nodes: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "("
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Node",
+                  "canonicalReference": "slimdom!default:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | string)[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isOptional": false,
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 5,
+                "endIndex": 6
+              },
+              "releaseTag": "Public",
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "nodes",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 4
+                  }
+                }
+              ],
+              "name": "replaceChildren"
+            },
+            {
+              "kind": "Method",
               "canonicalReference": "slimdom!Element#replaceWith:member(1)",
               "docComment": "",
               "excerptTokens": [
@@ -7121,7 +7283,7 @@
             {
               "kind": "Method",
               "canonicalReference": "slimdom!Node#_copy:member(1)",
-              "docComment": "/**\n * (non-standard) Creates a copy of the context object, not including its children.\n *\n * @param document - The node document to associate with the copy\n *\n * @returns A shallow copy of the context object\n */\n",
+              "docComment": "/**\n * (non-standard) Creates a copy of this, not including its children.\n *\n * @param document - The node document to associate with the copy\n *\n * @returns A shallow copy of this\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -7196,7 +7358,7 @@
             {
               "kind": "Method",
               "canonicalReference": "slimdom!Node#appendChild:member(1)",
-              "docComment": "/**\n * Adds node to the end of the list of children of the context object.\n *\n * If the node already exists it is removed from its current parent node, then added.\n *\n * @param node - Node to append\n *\n * @returns The node that was inserted\n */\n",
+              "docComment": "/**\n * Adds node to the end of the list of children of this.\n *\n * If the node already exists it is removed from its current parent node, then added.\n *\n * @param node - Node to append\n *\n * @returns The node that was inserted\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -7502,7 +7664,7 @@
             {
               "kind": "Method",
               "canonicalReference": "slimdom!Node#contains:member(1)",
-              "docComment": "/**\n * Returns true if other is an inclusive descendant of context object, and false otherwise (including when other is null).\n *\n * @param childNode - Node to check\n *\n * @returns Whether childNode is an inclusive descendant of the current node\n */\n",
+              "docComment": "/**\n * Returns true if other is an inclusive descendant of this, and false otherwise (including when other is null).\n *\n * @param childNode - Node to check\n *\n * @returns Whether childNode is an inclusive descendant of the current node\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -7908,7 +8070,7 @@
             {
               "kind": "Method",
               "canonicalReference": "slimdom!Node#hasChildNodes:member(1)",
-              "docComment": "/**\n * Returns true if the context object has children, and false otherwise.\n */\n",
+              "docComment": "/**\n * Returns true if this has children, and false otherwise.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -7937,7 +8099,7 @@
             {
               "kind": "Method",
               "canonicalReference": "slimdom!Node#insertBefore:member(1)",
-              "docComment": "/**\n * Inserts the specified node before child within context object.\n *\n * If child is null, the new node is appended after the last child node of the current node.\n *\n * @param node - Node to insert\n *\n * @param child - Childnode of the current node before which to insert, or null to append newNode at the end\n *\n * @returns The node that was inserted\n */\n",
+              "docComment": "/**\n * Inserts the specified node before child within this.\n *\n * If child is null, the new node is appended after the last child node of the current node.\n *\n * @param node - Node to insert\n *\n * @param child - Childnode of the current node before which to insert, or null to append newNode at the end\n *\n * @returns The node that was inserted\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -8573,7 +8735,7 @@
             {
               "kind": "Method",
               "canonicalReference": "slimdom!Node#removeChild:member(1)",
-              "docComment": "/**\n * Removes child from context object and returns the removed node.\n *\n * @param child - Child of the current node to remove\n *\n * @returns The node that was removed\n */\n",
+              "docComment": "/**\n * Removes child from this and returns the removed node.\n *\n * @param child - Child of the current node to remove\n *\n * @returns The node that was removed\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -8640,7 +8802,7 @@
             {
               "kind": "Method",
               "canonicalReference": "slimdom!Node#replaceChild:member(1)",
-              "docComment": "/**\n * Replaces child with node within context object and returns child.\n *\n * @param node - Node to insert\n *\n * @param child - Node to remove\n *\n * @returns The node that was removed\n */\n",
+              "docComment": "/**\n * Replaces child with node within this and returns child.\n *\n * @param node - Node to insert\n *\n * @param child - Node to remove\n *\n * @returns The node that was removed\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -8833,7 +8995,7 @@
             {
               "kind": "Method",
               "canonicalReference": "slimdom!ProcessingInstruction#_copy:member(1)",
-              "docComment": "/**\n * (non-standard) Creates a copy of the context object, not including its children.\n *\n * @param document - The node document to associate with the copy\n *\n * @returns A shallow copy of the context object\n */\n",
+              "docComment": "/**\n * (non-standard) Creates a copy of this, not including its children.\n *\n * @param document - The node document to associate with the copy\n *\n * @returns A shallow copy of this\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -9049,7 +9211,7 @@
             {
               "kind": "Method",
               "canonicalReference": "slimdom!Range#cloneRange:member(1)",
-              "docComment": "/**\n * Returns a range with the same start and end as the context object.\n *\n * @returns A copy of the context object\n */\n",
+              "docComment": "/**\n * Returns a range with the same start and end as this.\n *\n * @returns A copy of this\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -9485,7 +9647,7 @@
             {
               "kind": "Method",
               "canonicalReference": "slimdom!Range#isPointInRange:member(1)",
-              "docComment": "/**\n * Returns true if the given point is after or equal to the start point and before or equal to the end point of the context object.\n *\n * @param node - Node of point to check\n *\n * @param offset - Offset of point to check\n *\n * @returns Whether the point is in the range\n */\n",
+              "docComment": "/**\n * Returns true if the given point is after or equal to the start point and before or equal to the end point of this.\n *\n * @param node - Node of point to check\n *\n * @param offset - Offset of point to check\n *\n * @returns Whether the point is in the range\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -10104,6 +10266,204 @@
         },
         {
           "kind": "Class",
+          "canonicalReference": "slimdom!StaticRange:class",
+          "docComment": "/**\n * Interface StaticRange\n *\n * Updating live ranges in response to node tree mutations can be expensive. For every node tree change, all affected Range objects need to be updated. Even if the application is uninterested in some live ranges, it still has to pay the cost of keeping them up-to-date when a mutation occurs.\n *\n * A StaticRange object is a lightweight range that does not update when the node tree mutates. It is therefore not subject to the same maintenance cost as live ranges.\n *\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare class StaticRange implements "
+            },
+            {
+              "kind": "Reference",
+              "text": "AbstractRange",
+              "canonicalReference": "slimdom!AbstractRange:interface"
+            },
+            {
+              "kind": "Content",
+              "text": " "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "StaticRange",
+          "members": [
+            {
+              "kind": "Constructor",
+              "canonicalReference": "slimdom!StaticRange:constructor(1)",
+              "docComment": "/**\n * The StaticRange(init) constructor, when invoked, must run these steps:\n *\n * @param init - Dictionary representing the properties to set on the StaticRange\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "constructor(init: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "StaticRangeInit",
+                  "canonicalReference": "slimdom!~StaticRangeInit:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ");"
+                }
+              ],
+              "releaseTag": "Public",
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "init",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "slimdom!StaticRange#collapsed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly collapsed: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "collapsed",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "slimdom!StaticRange#endContainer:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly endContainer: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Node",
+                  "canonicalReference": "slimdom!default:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "endContainer",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "slimdom!StaticRange#endOffset:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly endOffset: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "number"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "endOffset",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "slimdom!StaticRange#startContainer:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly startContainer: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Node",
+                  "canonicalReference": "slimdom!default:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "startContainer",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "slimdom!StaticRange#startOffset:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly startOffset: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "number"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "startOffset",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false
+            }
+          ],
+          "implementsTokenRanges": [
+            {
+              "startIndex": 1,
+              "endIndex": 3
+            }
+          ]
+        },
+        {
+          "kind": "Class",
           "canonicalReference": "slimdom!Text:class",
           "docComment": "/**\n * 3.11. Interface Text\n *\n * @public\n */\n",
           "excerptTokens": [
@@ -10127,7 +10487,7 @@
             {
               "kind": "Method",
               "canonicalReference": "slimdom!Text#_copy:member(1)",
-              "docComment": "/**\n * (non-standard) Creates a copy of the context object, not including its children.\n *\n * @param document - The node document to associate with the copy\n *\n * @returns A shallow copy of the context object\n */\n",
+              "docComment": "/**\n * (non-standard) Creates a copy of this, not including its children.\n *\n * @param document - The node document to associate with the copy\n *\n * @returns A shallow copy of this\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -10304,7 +10664,7 @@
             {
               "kind": "Property",
               "canonicalReference": "slimdom!Text#wholeText:member",
-              "docComment": "/**\n * Returns the combined data of all direct Text node siblings.\n *\n * @returns the concatenation of the data of the contiguous Text nodes of the context object, in tree order.\n */\n",
+              "docComment": "/**\n * Returns the combined data of all direct Text node siblings.\n *\n * @returns the concatenation of the data of the contiguous Text nodes of this, in tree order.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -10619,7 +10979,7 @@
             {
               "kind": "Method",
               "canonicalReference": "slimdom!XMLDocument#_copy:member(1)",
-              "docComment": "/**\n * (non-standard) Creates a copy of the context object, not including its children.\n *\n * @param document - The node document to associate with the copy\n *\n * @returns A shallow copy of the context object\n */\n",
+              "docComment": "/**\n * (non-standard) Creates a copy of this, not including its children.\n *\n * @param document - The node document to associate with the copy\n *\n * @returns A shallow copy of this\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",

--- a/api/slimdom.api.json
+++ b/api/slimdom.api.json
@@ -2620,6 +2620,121 @@
               "isStatic": false
             },
             {
+              "kind": "Method",
+              "canonicalReference": "slimdom!Document#getElementsByTagName:member(1)",
+              "docComment": "/**\n * Returns the list of elements with the given qualified name.\n *\n * @param qualifiedName - Qualified name of the elements to collect.\n *\n * @returns The list of elements with matching qualified name.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getElementsByTagName(qualifiedName: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Element",
+                  "canonicalReference": "slimdom!default:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isOptional": false,
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 5
+              },
+              "releaseTag": "Public",
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "qualifiedName",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  }
+                }
+              ],
+              "name": "getElementsByTagName"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "slimdom!Document#getElementsByTagNameNS:member(1)",
+              "docComment": "/**\n * Returns the list of elements with the given namespace and local name.\n *\n * @param namespace - Namespace URI of the elements to collect.\n *\n * @param localName - Local name of the elements to collect\n *\n * @returns The list of elements with matching namespace and local name.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getElementsByTagNameNS(namespace: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string | null"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", localName: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Element",
+                  "canonicalReference": "slimdom!default:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isOptional": false,
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 5,
+                "endIndex": 7
+              },
+              "releaseTag": "Public",
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "namespace",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  }
+                },
+                {
+                  "parameterName": "localName",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 3,
+                    "endIndex": 4
+                  }
+                }
+              ],
+              "name": "getElementsByTagNameNS"
+            },
+            {
               "kind": "Property",
               "canonicalReference": "slimdom!Document#implementation:member",
               "docComment": "/**\n * Returns a reference to the DOMImplementation object associated with the document.\n */\n",

--- a/api/slimdom.api.md
+++ b/api/slimdom.api.md
@@ -146,6 +146,8 @@ export class Document extends Node implements NonElementParentNode, ParentNode {
     // (undocumented)
     prepend(...nodes: (Node | string)[]): void;
     // (undocumented)
+    replaceChildren(...nodes: (Node | string)[]): void;
+    // (undocumented)
     get textContent(): string | null;
     set textContent(_newValue: string | null);
 }
@@ -180,6 +182,8 @@ export class DocumentFragment extends Node implements NonElementParentNode, Pare
     set nodeValue(newValue: string | null);
     // (undocumented)
     prepend(...nodes: (Node | string)[]): void;
+    // (undocumented)
+    replaceChildren(...nodes: (Node | string)[]): void;
     // (undocumented)
     get textContent(): string | null;
     set textContent(newValue: string | null);
@@ -280,6 +284,8 @@ export class Element extends Node implements ParentNode, NonDocumentTypeChildNod
     removeAttribute(qualifiedName: string): void;
     removeAttributeNode(attr: Attr): Attr;
     removeAttributeNS(namespace: string | null, localName: string): void;
+    // (undocumented)
+    replaceChildren(...nodes: (Node | string)[]): void;
     // (undocumented)
     replaceWith(...nodes: (Node | string)[]): void;
     setAttribute(qualifiedName: string, value: string): void;
@@ -462,6 +468,22 @@ export class Range implements AbstractRange {
 
 // @public
 export function serializeToWellFormedString(root: Node): string;
+
+// @public
+export class StaticRange implements AbstractRange {
+    // Warning: (ae-forgotten-export) The symbol "StaticRangeInit" needs to be exported by the entry point index.d.ts
+    constructor(init: StaticRangeInit);
+    // (undocumented)
+    readonly collapsed: boolean;
+    // (undocumented)
+    readonly endContainer: Node;
+    // (undocumented)
+    readonly endOffset: number;
+    // (undocumented)
+    readonly startContainer: Node;
+    // (undocumented)
+    readonly startOffset: number;
+}
 
 // @public
 export class Text extends CharacterData {

--- a/api/slimdom.api.md
+++ b/api/slimdom.api.md
@@ -126,6 +126,8 @@ export class Document extends Node implements NonElementParentNode, ParentNode {
     documentElement: Element | null;
     // (undocumented)
     firstElementChild: Element | null;
+    getElementsByTagName(qualifiedName: string): Element[];
+    getElementsByTagNameNS(namespace: string | null, localName: string): Element[];
     readonly implementation: DOMImplementation;
     importNode<TNode extends Node>(node: TNode, deep?: boolean): TNode;
     // (undocumented)

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"rollup": "^2.38.1",
 		"rollup-plugin-sourcemaps": "^0.6.3",
 		"rollup-plugin-terser": "^7.0.2",
+		"sizzle": "^2.3.5",
 		"ts-jest": "~26.5.0",
 		"typescript": "^4.1.3"
 	},

--- a/src/Attr.ts
+++ b/src/Attr.ts
@@ -31,7 +31,7 @@ export default class Attr extends Node {
 	public set nodeValue(newValue: string | null) {
 		newValue = treatNullAsEmptyString(newValue);
 
-		// Set an existing attribute value with context object and new value.
+		// Set an existing attribute value with this and new value.
 		setExistingAttributeValue(this, newValue);
 	}
 
@@ -42,7 +42,7 @@ export default class Attr extends Node {
 	public set textContent(newValue: string | null) {
 		newValue = treatNullAsEmptyString(newValue);
 
-		// Set an existing attribute value with context object and new value.
+		// Set an existing attribute value with this and new value.
 		setExistingAttributeValue(this, newValue);
 	}
 
@@ -52,7 +52,7 @@ export default class Attr extends Node {
 		// 1. If namespace is null or the empty string, then return null.
 		// (not necessary due to recursion)
 
-		// 2. Switch on the context object:
+		// 2. Switch on this:
 		// Attr - Return the result of locating a namespace prefix for its element, if its element
 		// is non-null, and null otherwise.
 		if (this.ownerElement !== null) {
@@ -68,7 +68,7 @@ export default class Attr extends Node {
 		// 1. If prefix is the empty string, then set it to null.
 		// (not necessary due to recursion)
 
-		// 2. Return the result of running locate a namespace for the context object using prefix.
+		// 2. Return the result of running locate a namespace for this using prefix.
 
 		// To locate a namespace for a node using prefix, switch on node: Attr
 		// 1. If its element is null, then return null.
@@ -128,11 +128,11 @@ export default class Attr extends Node {
 	}
 
 	/**
-	 * (non-standard) Creates a copy of the context object, not including its children.
+	 * (non-standard) Creates a copy of this, not including its children.
 	 *
 	 * @param document - The node document to associate with the copy
 	 *
-	 * @returns A shallow copy of the context object
+	 * @returns A shallow copy of this
 	 */
 	public _copy(document: Document): Attr {
 		// Set copy’s namespace, namespace prefix, local name, and value, to those of node.
@@ -164,7 +164,7 @@ function setExistingAttributeValue(attribute: Attr, value: string) {
 	if (element === null) {
 		(attribute as any)._value = value;
 	} else {
-		// 2. Otherwise, change attribute from attribute’s element to value.
-		changeAttribute(attribute, element, value);
+		// 2. Otherwise, change attribute to value.
+		changeAttribute(attribute, value);
 	}
 }

--- a/src/CDATASection.ts
+++ b/src/CDATASection.ts
@@ -29,11 +29,11 @@ export default class CDATASection extends Text {
 	}
 
 	/**
-	 * (non-standard) Creates a copy of the context object, not including its children.
+	 * (non-standard) Creates a copy of this, not including its children.
 	 *
 	 * @param document - The node document to associate with the copy
 	 *
-	 * @returns A shallow copy of the context object
+	 * @returns A shallow copy of this
 	 */
 	public _copy(document: Document): CDATASection {
 		// Set copy’s data, to that of node.

--- a/src/CharacterData.ts
+++ b/src/CharacterData.ts
@@ -34,7 +34,7 @@ export default abstract class CharacterData
 	public set nodeValue(newValue: string | null) {
 		newValue = treatNullAsEmptyString(newValue);
 
-		// Set an existing attribute value with context object and new value.
+		// Set an existing attribute value with this and new value.
 		replaceData(this, 0, this.length, newValue);
 	}
 
@@ -45,7 +45,7 @@ export default abstract class CharacterData
 	public set textContent(newValue: string | null) {
 		newValue = treatNullAsEmptyString(newValue);
 
-		// Set an existing attribute value with context object and new value.
+		// Set an existing attribute value with this and new value.
 		replaceData(this, 0, this.length, newValue);
 	}
 
@@ -55,7 +55,7 @@ export default abstract class CharacterData
 		// 1. If namespace is null or the empty string, then return null.
 		// (not necessary due to recursion)
 
-		// 2. Switch on the context object:
+		// 2. Switch on this:
 		// Any other node - Return the result of locating a namespace prefix for its parent element,
 		// if its parent element is non-null, and null otherwise.
 		const parentElement = this.parentElement;
@@ -72,7 +72,7 @@ export default abstract class CharacterData
 		// 1. If prefix is the empty string, then set it to null.
 		// (not necessary due to recursion)
 
-		// 2. Return the result of running locate a namespace for the context object using prefix.
+		// 2. Return the result of running locate a namespace for this using prefix.
 
 		// To locate a namespace for a node using prefix, switch on node: Any other node
 		// 1. If its parent element is null, then return null.
@@ -129,7 +129,7 @@ export default abstract class CharacterData
 		// [TreatNullAs=EmptyString]
 		newValue = treatNullAsEmptyString(newValue);
 
-		// replace data with node context object, offset 0, count context object’s length, and data
+		// replace data with node this, offset 0, count this’s length, and data
 		// new value.
 		replaceData(this, 0, this.length, newValue);
 	}
@@ -285,9 +285,8 @@ export function replaceData(
 		}
 	});
 
-	// 12. If node is a Text node and its parent is not null, run the child text content change
-	// steps for node’s parent.
-	// (child text content change steps not implemented)
+	// 12. If node's parent is non-null, then run the children changed steps for node’s parent.
+	// (children changed steps not implemented)
 }
 
 /**

--- a/src/Comment.ts
+++ b/src/Comment.ts
@@ -33,11 +33,11 @@ export default class Comment extends CharacterData {
 	}
 
 	/**
-	 * (non-standard) Creates a copy of the context object, not including its children.
+	 * (non-standard) Creates a copy of this, not including its children.
 	 *
 	 * @param document - The node document to associate with the copy
 	 *
-	 * @returns A shallow copy of the context object
+	 * @returns A shallow copy of this
 	 */
 	public _copy(document: Document): Comment {
 		// Set copy’s data, to that of node.

--- a/src/DOMImplementation.ts
+++ b/src/DOMImplementation.ts
@@ -43,7 +43,7 @@ export default class DOMImplementation {
 
 		// 2. Return a new doctype, with qualifiedName as its name, publicId as its public ID, and
 		// systemId as its system ID, and with its node document set to the associated document of
-		// the context object.
+		// this.
 		const context = getContext(this._document);
 		const doctype = new context.DocumentType(qualifiedName, publicId, systemId);
 		doctype.ownerDocument = this._document;
@@ -97,7 +97,7 @@ export default class DOMImplementation {
 			document.appendChild(element);
 		}
 
-		// 6. document’s origin is context object’s associated document’s origin.
+		// 6. document’s origin is this’s associated document’s origin.
 		// (origin not implemented)
 
 		// 7. document’s content type is determined by namespace:
@@ -159,7 +159,7 @@ export default class DOMImplementation {
 		// the html element created earlier.
 		htmlElement.appendChild(createElement(doc, 'body', HTML_NAMESPACE));
 
-		// 8. doc’s origin is context object’s associated document’s origin.
+		// 8. doc’s origin is this’s associated document’s origin.
 		// (origin not implemented)
 
 		// 9. Return doc.

--- a/src/Document.ts
+++ b/src/Document.ts
@@ -18,7 +18,7 @@ import {
 	throwInvalidCharacterError,
 	throwNotSupportedError,
 } from './util/errorHelpers';
-import { adoptNode, appendNodes, prependNodes } from './util/mutationAlgorithms';
+import { adoptNode, appendNodes, prependNodes, replaceChildren } from './util/mutationAlgorithms';
 import { NodeType, isNodeOfType } from './util/NodeType';
 import { matchesNameProduction, validateAndExtract } from './util/namespaceHelpers';
 import { asNullableString, asObject } from './util/typeHelpers';
@@ -62,7 +62,7 @@ export default class Document extends Node implements NonElementParentNode, Pare
 		// 1. If namespace is null or the empty string, then return null.
 		// (not necessary due to recursion)
 
-		// 2. Switch on the context object:
+		// 2. Switch on this:
 		// Document - Return the result of locating a namespace prefix for its document element, if
 		// its document element is non-null, and null otherwise.
 		if (this.documentElement !== null) {
@@ -78,7 +78,7 @@ export default class Document extends Node implements NonElementParentNode, Pare
 		// 1. If prefix is the empty string, then set it to null.
 		// (not necessary due to recursion)
 
-		// 2. Return the result of running locate a namespace for the context object using prefix.
+		// 2. Return the result of running locate a namespace for this using prefix.
 
 		// To locate a namespace for a node using prefix, switch on node: Document
 		// 1. If its document element is null, then return null.
@@ -106,6 +106,10 @@ export default class Document extends Node implements NonElementParentNode, Pare
 
 	public append(...nodes: (Node | string)[]): void {
 		appendNodes(this, nodes);
+	}
+
+	public replaceChildren(...nodes: (Node | string)[]): void {
+		replaceChildren(this, nodes);
 	}
 
 	// Document
@@ -237,19 +241,19 @@ export default class Document extends Node implements NonElementParentNode, Pare
 			throwInvalidCharacterError('The local name is not a valid Name');
 		}
 
-		// 2. If the context object is an HTML document, then set localName to localName in ASCII
+		// 2. If this is an HTML document, then set localName to localName in ASCII
 		// lowercase.
 		// (html documents not implemented)
 
 		// 3. Let is be the value of is member of options, or null if no such member exists.
 		// (custom elements not implemented)
 
-		// 4. Let namespace be the HTML namespace, if the context object is an HTML document or
-		// context object’s content type is "application/xhtml+xml", and null otherwise.
+		// 4. Let namespace be the HTML namespace, if this is an HTML document or
+		// this’s content type is "application/xhtml+xml", and null otherwise.
 		// (html documents not implemented)
 		const namespace: string | null = null;
 
-		// 5. Let element be the result of creating an element given the context object, localName,
+		// 5. Let element be the result of creating an element given this, localName,
 		// namespace, null, is, and with the synchronous custom elements flag set.
 		const element = createElement(this, localName, namespace, null);
 
@@ -273,13 +277,13 @@ export default class Document extends Node implements NonElementParentNode, Pare
 		namespace = asNullableString(namespace);
 		qualifiedName = String(qualifiedName);
 
-		// return the result of running the internal createElementNS steps, given context object,
+		// return the result of running the internal createElementNS steps, given this,
 		// namespace, qualifiedName, and options.
 		return createElementNS(this, namespace, qualifiedName);
 	}
 
 	/**
-	 * Returns a new DocumentFragment node with its node document set to the context object.
+	 * Returns a new DocumentFragment node with its node document set to this.
 	 *
 	 * @returns The new document fragment
 	 */
@@ -309,7 +313,7 @@ export default class Document extends Node implements NonElementParentNode, Pare
 	}
 
 	/**
-	 * Returns a new CDATA section with the given data and node document set to the context object.
+	 * Returns a new CDATA section with the given data and node document set to this.
 	 *
 	 * @param data - Data for the new CDATA section
 	 *
@@ -319,7 +323,7 @@ export default class Document extends Node implements NonElementParentNode, Pare
 		expectArity(arguments, 1);
 		data = String(data);
 
-		// 1. If context object is an HTML document, then throw a NotSupportedError.
+		// 1. If this is an HTML document, then throw a NotSupportedError.
 		// (html documents not implemented)
 
 		// 2. If data contains the string "]]>", then throw an InvalidCharacterError.
@@ -328,7 +332,7 @@ export default class Document extends Node implements NonElementParentNode, Pare
 		}
 
 		// 3. Return a new CDATASection node with its data set to data and node document set to the
-		// context object.
+		// this.
 		const context = getContext(this);
 		const cdataSection = new context.CDATASection(data);
 		cdataSection.ownerDocument = this;
@@ -355,7 +359,7 @@ export default class Document extends Node implements NonElementParentNode, Pare
 
 	/**
 	 * Creates a new processing instruction node, with target set to target, data set to data, and
-	 * node document set to the context object.
+	 * node document set to this.
 	 *
 	 * @param target - Target for the new processing instruction
 	 * @param data   - Data for the new processing instruction
@@ -378,7 +382,7 @@ export default class Document extends Node implements NonElementParentNode, Pare
 		}
 
 		// 3. Return a new ProcessingInstruction node, with target set to target, data set to data,
-		// and node document set to the context object.
+		// and node document set to this.
 		const context = getContext(this);
 		const pi = new context.ProcessingInstruction(target, data);
 		pi.ownerDocument = this;
@@ -404,7 +408,7 @@ export default class Document extends Node implements NonElementParentNode, Pare
 			throwNotSupportedError('importing a Document node is not supported');
 		}
 
-		// 2. Return a clone of node, with context object and the clone children flag set if deep is
+		// 2. Return a clone of node, with this and the clone children flag set if deep is
 		// true.
 		return cloneNode(node, deep, this);
 	}
@@ -426,12 +430,13 @@ export default class Document extends Node implements NonElementParentNode, Pare
 		}
 
 		// 2. If node is a shadow root, then throw a HierarchyRequestError.
+		// 3. If node is a DocumentFragment whose host is non-null, then return.
 		// (shadow dom not implemented)
 
-		// 3. Adopt node into the context object.
+		// 4. Adopt node into this.
 		adoptNode(node, this);
 
-		// 4. Return node.
+		// 5. Return node.
 		return node;
 	}
 
@@ -452,7 +457,7 @@ export default class Document extends Node implements NonElementParentNode, Pare
 			throwInvalidCharacterError('The local name is not a valid Name');
 		}
 
-		// 2. If the context object is an HTML document, then set localName to localName in ASCII
+		// 2. If this is an HTML document, then set localName to localName in ASCII
 		// lowercase.
 		// (html documents not implemented)
 
@@ -485,7 +490,7 @@ export default class Document extends Node implements NonElementParentNode, Pare
 		);
 
 		// 2. Return a new attribute whose namespace is namespace, namespace prefix is prefix, local
-		// name is localName, and node document is context object.
+		// name is localName, and node document is this.
 		const context = getContext(this);
 		const attr = new context.Attr(validatedNamespace, prefix, localName, '', null);
 		attr.ownerDocument = this;
@@ -508,11 +513,11 @@ export default class Document extends Node implements NonElementParentNode, Pare
 	}
 
 	/**
-	 * (non-standard) Creates a copy of the context object, not including its children.
+	 * (non-standard) Creates a copy of this, not including its children.
 	 *
 	 * @param document - The node document to associate with the copy
 	 *
-	 * @returns A shallow copy of the context object
+	 * @returns A shallow copy of this
 	 */
 	public _copy(document: Document): Document {
 		// Set copy’s encoding, content type, URL, origin, type, and mode, to those of node.

--- a/src/Document.ts
+++ b/src/Document.ts
@@ -22,6 +22,7 @@ import { adoptNode, appendNodes, prependNodes } from './util/mutationAlgorithms'
 import { NodeType, isNodeOfType } from './util/NodeType';
 import { matchesNameProduction, validateAndExtract } from './util/namespaceHelpers';
 import { asNullableString, asObject } from './util/typeHelpers';
+import { forEachInclusiveDescendant } from './util/treeHelpers';
 
 /**
  * 3.5. Interface Document
@@ -132,6 +133,92 @@ export default class Document extends Node implements NonElementParentNode, Pare
 	 */
 	constructor() {
 		super();
+	}
+
+	/**
+	 * Returns the list of elements with the given qualified name.
+	 *
+	 * @param qualifiedName - Qualified name of the elements to collect.
+	 *
+	 * @returns  The list of elements with matching qualified name.
+	 */
+	public getElementsByTagName(qualifiedName: string): Element[] {
+		expectArity(arguments, 1);
+		qualifiedName = String(qualifiedName);
+
+		const elements: Element[] = [];
+		forEachInclusiveDescendant(this, (node) => {
+			if (node.nodeType !== NodeType.ELEMENT_NODE) {
+				return;
+			}
+			const element = node as Element;
+
+			if (
+				// 1. If qualifiedName is "*" (U+002A), return a HTMLCollection rooted at root,
+				//    whose filter matches only descendant elements.
+				qualifiedName === '\u002a' ||
+				// 2. Otherwise, if root’s node document is an HTML document,
+				//    return a HTMLCollection rooted at root, whose filter matches the following
+				//    descendant elements:
+				//    - Whose namespace is the HTML namespace and whose qualified name is qualifiedName,
+				//      in ASCII lowercase.
+				//    - Whose namespace is not the HTML namespace and whose qualified name is
+				//      qualifiedName.
+				// (html documents not implemented)
+
+				// 3. Otherwise, return a HTMLCollection rooted at root, whose filter matches
+				//    descendant elements whose qualified name is qualifiedName.
+				element.nodeName === qualifiedName
+			) {
+				elements.push(element);
+			}
+		});
+
+		return elements;
+	}
+
+	/**
+	 * Returns the list of elements with the given namespace and local name.
+	 *
+	 * @param namespace - Namespace URI of the elements to collect.
+	 * @param localName - Local name of the elements to collect
+	 *
+	 * @returns  The list of elements with matching namespace and local name.
+	 */
+	public getElementsByTagNameNS(namespace: string | null, localName: string): Element[] {
+		expectArity(arguments, 2);
+		namespace = asNullableString(namespace);
+		localName = String(localName);
+
+		// 1. If namespace is the empty string, set it to null.
+		if (namespace === '') {
+			namespace = null;
+		}
+
+		const elements: Element[] = [];
+		forEachInclusiveDescendant(this, (node) => {
+			if (node.nodeType !== NodeType.ELEMENT_NODE) {
+				return;
+			}
+			const element = node as Element;
+
+			if (
+				// 2. If both namespace and localName are "*" (U+002A), return a HTMLCollection
+				//    rooted at root, whose filter matches descendant elements.
+				// 3. Otherwise, if namespace is "*" (U+002A), return a HTMLCollection rooted at
+				//    root, whose filter matches descendant elements whose local name is localName.
+				// 4. Otherwise, if localName is "*" (U+002A), return a HTMLCollection rooted at
+				//    root, whose filter matches descendant elements whose namespace is namespace.
+				// 5. Otherwise, return a HTMLCollection rooted at root, whose filter matches
+				//    descendant elements whose namespace is namespace and local name is localName.
+				(namespace === '\u002a' || element.namespaceURI === namespace) &&
+				(localName === '\u002a' || element.localName === localName)
+			) {
+				elements.push(element);
+			}
+		});
+
+		return elements;
 	}
 
 	/**

--- a/src/DocumentFragment.ts
+++ b/src/DocumentFragment.ts
@@ -7,8 +7,9 @@ import { expectArity } from './util/errorHelpers';
 import {
 	appendNodes,
 	prependNodes,
-	getConcatenatedTextNodesData,
-	setTextContentByReplacing,
+	getDescendantTextContent,
+	stringReplaceAll,
+	replaceChildren,
 } from './util/mutationAlgorithms';
 import { NodeType } from './util/NodeType';
 import { treatNullAsEmptyString } from './util/typeHelpers';
@@ -36,14 +37,13 @@ export default class DocumentFragment extends Node implements NonElementParentNo
 	}
 
 	public get textContent(): string | null {
-		// Return the concatenation of data of all the Text node descendants of
-		// the context object, in tree order
-		return getConcatenatedTextNodesData(this);
+		// Return the descendant text content of this
+		return getDescendantTextContent(this);
 	}
 
 	public set textContent(newValue: string | null) {
 		newValue = treatNullAsEmptyString(newValue);
-		setTextContentByReplacing(this, newValue);
+		stringReplaceAll(this, newValue);
 	}
 
 	public lookupPrefix(namespace: string | null): string | null {
@@ -52,7 +52,7 @@ export default class DocumentFragment extends Node implements NonElementParentNo
 		// 1. If namespace is null or the empty string, then return null.
 		// (not necessary due to return value)
 
-		// 2. Switch on the context object:
+		// 2. Switch on this:
 		// DocumentFragment - Return null
 		return null;
 	}
@@ -63,7 +63,7 @@ export default class DocumentFragment extends Node implements NonElementParentNo
 		// 1. If prefix is the empty string, then set it to null.
 		// (not necessary due to return value)
 
-		// 2. Return the result of running locate a namespace for the context object using prefix.
+		// 2. Return the result of running locate a namespace for this using prefix.
 
 		// To locate a namespace for a node using prefix, switch on node: DocumentFragment
 		// Return null.
@@ -88,6 +88,10 @@ export default class DocumentFragment extends Node implements NonElementParentNo
 		appendNodes(this, nodes);
 	}
 
+	public replaceChildren(...nodes: (Node | string)[]): void {
+		replaceChildren(this, nodes);
+	}
+
 	/**
 	 * Return a new DocumentFragment node whose node document is current global object’s associated
 	 * Document.
@@ -100,11 +104,11 @@ export default class DocumentFragment extends Node implements NonElementParentNo
 	}
 
 	/**
-	 * (non-standard) Creates a copy of the context object, not including its children.
+	 * (non-standard) Creates a copy of this, not including its children.
 	 *
 	 * @param document - The node document to associate with the copy
 	 *
-	 * @returns A shallow copy of the context object
+	 * @returns A shallow copy of this
 	 */
 	public _copy(document: Document): DocumentFragment {
 		const context = getContext(document);

--- a/src/DocumentType.ts
+++ b/src/DocumentType.ts
@@ -47,7 +47,7 @@ export default class DocumentType extends Node implements ChildNode {
 		// 1. If namespace is null or the empty string, then return null.
 		// (not necessary due to return value)
 
-		// 2. Switch on the context object:
+		// 2. Switch on this:
 		// DocumentType - Return null
 		return null;
 	}
@@ -58,7 +58,7 @@ export default class DocumentType extends Node implements ChildNode {
 		// 1. If prefix is the empty string, then set it to null.
 		// (not necessary due to return value)
 
-		// 2. Return the result of running locate a namespace for the context object using prefix.
+		// 2. Return the result of running locate a namespace for this using prefix.
 
 		// To locate a namespace for a node using prefix, switch on node: DocumentType
 		// Return null.
@@ -116,11 +116,11 @@ export default class DocumentType extends Node implements ChildNode {
 	}
 
 	/**
-	 * (non-standard) Creates a copy of the context object, not including its children.
+	 * (non-standard) Creates a copy of this, not including its children.
 	 *
 	 * @param document - The node document to associate with the copy
 	 *
-	 * @returns A shallow copy of the context object
+	 * @returns A shallow copy of this
 	 */
 	public _copy(document: Document): DocumentType {
 		// Set copy’s name, public ID, and system ID, to those of node.

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -27,28 +27,28 @@ export default abstract class Node {
 	static ATTRIBUTE_NODE: number = NodeType.ATTRIBUTE_NODE;
 	static TEXT_NODE: number = NodeType.TEXT_NODE;
 	static CDATA_SECTION_NODE: number = NodeType.CDATA_SECTION_NODE;
-	static ENTITY_REFERENCE_NODE: number = NodeType.ENTITY_REFERENCE_NODE; // historical
-	static ENTITY_NODE: number = NodeType.ENTITY_NODE; // historical
+	static ENTITY_REFERENCE_NODE: number = NodeType.ENTITY_REFERENCE_NODE; // legacy
+	static ENTITY_NODE: number = NodeType.ENTITY_NODE; // legacy
 	static PROCESSING_INSTRUCTION_NODE: number = NodeType.PROCESSING_INSTRUCTION_NODE;
 	static COMMENT_NODE: number = NodeType.COMMENT_NODE;
 	static DOCUMENT_NODE: number = NodeType.DOCUMENT_NODE;
 	static DOCUMENT_TYPE_NODE: number = NodeType.DOCUMENT_TYPE_NODE;
 	static DOCUMENT_FRAGMENT_NODE: number = NodeType.DOCUMENT_FRAGMENT_NODE;
-	static NOTATION_NODE: number = NodeType.NOTATION_NODE; // historical
+	static NOTATION_NODE: number = NodeType.NOTATION_NODE; // legacy
 
 	// Node types also exist as instance properties, assigned to the prototype below
 	public ELEMENT_NODE!: number;
 	public ATTRIBUTE_NODE!: number;
 	public TEXT_NODE!: number;
 	public CDATA_SECTION_NODE!: number;
-	public ENTITY_REFERENCE_NODE!: number; // historical
-	public ENTITY_NODE!: number; // historical
+	public ENTITY_REFERENCE_NODE!: number; // legacy
+	public ENTITY_NODE!: number; // legacy
 	public PROCESSING_INSTRUCTION_NODE!: number;
 	public COMMENT_NODE!: number;
 	public DOCUMENT_NODE!: number;
 	public DOCUMENT_TYPE_NODE!: number;
 	public DOCUMENT_FRAGMENT_NODE!: number;
-	public NOTATION_NODE!: number; // historical
+	public NOTATION_NODE!: number; // legacy
 
 	/**
 	 * Returns the type of node, represented by a number.
@@ -80,7 +80,7 @@ export default abstract class Node {
 	}
 
 	/**
-	 * Returns true if the context object has children, and false otherwise.
+	 * Returns true if this has children, and false otherwise.
 	 */
 	public hasChildNodes(): boolean {
 		return !!this.childNodes.length;
@@ -137,7 +137,7 @@ export default abstract class Node {
 	 * subtree, no text nodes in the subtree are empty and there are no adjacent text nodes.
 	 */
 	public normalize(): void {
-		// for each descendant exclusive Text node node of context object:
+		// for each descendant exclusive Text node node of this:
 		let node = this.firstChild;
 		let index = 0;
 		const document = getNodeDocument(this);
@@ -157,7 +157,7 @@ export default abstract class Node {
 			// 2. If length is zero, then remove node and continue with the next exclusive Text
 			// node, if any.
 			if (length === 0) {
-				removeNode(node, this);
+				removeNode(node);
 				--index;
 				node = nextNode;
 				continue;
@@ -229,17 +229,13 @@ export default abstract class Node {
 
 			// 7. Remove node’s contiguous exclusive Text nodes (excluding itself), in tree order.
 			while (siblingsToRemove.length) {
-				removeNode(siblingsToRemove.shift() as Node, this);
+				removeNode(siblingsToRemove.shift() as Node);
 			}
 
 			// Move to next node
 			node = node.nextSibling;
 			++index;
 		}
-
-		// Note: normalize() does not need to run any child text content change steps, since
-		// although it messes with Text nodes extensively, it does so specifically in a way that
-		// preserves the child text content.
 	}
 
 	/**
@@ -254,7 +250,7 @@ export default abstract class Node {
 	}
 
 	/**
-	 * Returns true if other is an inclusive descendant of context object, and false otherwise
+	 * Returns true if other is an inclusive descendant of this, and false otherwise
 	 * (including when other is null).
 	 *
 	 * @param childNode - Node to check
@@ -305,7 +301,7 @@ export default abstract class Node {
 			namespace = null;
 		}
 
-		// 2. Let defaultNamespace be the result of running locate a namespace for context object
+		// 2. Let defaultNamespace be the result of running locate a namespace for this
 		// using null.
 		const defaultNamespace = this.lookupNamespaceURI(null);
 
@@ -314,7 +310,7 @@ export default abstract class Node {
 	}
 
 	/**
-	 * Inserts the specified node before child within context object.
+	 * Inserts the specified node before child within this.
 	 *
 	 * If child is null, the new node is appended after the last child node of the current node.
 	 *
@@ -333,7 +329,7 @@ export default abstract class Node {
 	}
 
 	/**
-	 * Adds node to the end of the list of children of the context object.
+	 * Adds node to the end of the list of children of this.
 	 *
 	 * If the node already exists it is removed from its current parent node, then added.
 	 *
@@ -349,7 +345,7 @@ export default abstract class Node {
 	}
 
 	/**
-	 * Replaces child with node within context object and returns child.
+	 * Replaces child with node within this and returns child.
 	 *
 	 * @param node  - Node to insert
 	 * @param child - Node to remove
@@ -365,7 +361,7 @@ export default abstract class Node {
 	}
 
 	/**
-	 * Removes child from context object and returns the removed node.
+	 * Removes child from this and returns the removed node.
 	 *
 	 * @param child - Child of the current node to remove
 	 *
@@ -379,11 +375,11 @@ export default abstract class Node {
 	}
 
 	/**
-	 * (non-standard) Creates a copy of the context object, not including its children.
+	 * (non-standard) Creates a copy of this, not including its children.
 	 *
 	 * @param document - The node document to associate with the copy
 	 *
-	 * @returns A shallow copy of the context object
+	 * @returns A shallow copy of this
 	 */
 	public abstract _copy(document: Document): Node;
 }
@@ -392,11 +388,11 @@ Node.prototype.ELEMENT_NODE = NodeType.ELEMENT_NODE;
 Node.prototype.ATTRIBUTE_NODE = NodeType.ATTRIBUTE_NODE;
 Node.prototype.TEXT_NODE = NodeType.TEXT_NODE;
 Node.prototype.CDATA_SECTION_NODE = NodeType.CDATA_SECTION_NODE;
-Node.prototype.ENTITY_REFERENCE_NODE = NodeType.ENTITY_REFERENCE_NODE; // historical
-Node.prototype.ENTITY_NODE = NodeType.ENTITY_NODE; // historical
+Node.prototype.ENTITY_REFERENCE_NODE = NodeType.ENTITY_REFERENCE_NODE; // legacy
+Node.prototype.ENTITY_NODE = NodeType.ENTITY_NODE; // legacy
 Node.prototype.PROCESSING_INSTRUCTION_NODE = NodeType.PROCESSING_INSTRUCTION_NODE;
 Node.prototype.COMMENT_NODE = NodeType.COMMENT_NODE;
 Node.prototype.DOCUMENT_NODE = NodeType.DOCUMENT_NODE;
 Node.prototype.DOCUMENT_TYPE_NODE = NodeType.DOCUMENT_TYPE_NODE;
 Node.prototype.DOCUMENT_FRAGMENT_NODE = NodeType.DOCUMENT_FRAGMENT_NODE;
-Node.prototype.NOTATION_NODE = NodeType.NOTATION_NODE; // historical
+Node.prototype.NOTATION_NODE = NodeType.NOTATION_NODE; // legacy

--- a/src/ProcessingInstruction.ts
+++ b/src/ProcessingInstruction.ts
@@ -36,11 +36,11 @@ export default class ProcessingInstruction extends CharacterData {
 	}
 
 	/**
-	 * (non-standard) Creates a copy of the context object, not including its children.
+	 * (non-standard) Creates a copy of this, not including its children.
 	 *
 	 * @param document - The node document to associate with the copy
 	 *
-	 * @returns A shallow copy of the context object
+	 * @returns A shallow copy of this
 	 */
 	public _copy(document: Document): ProcessingInstruction {
 		// Set copy’s target and data to those of node.

--- a/src/Range.ts
+++ b/src/Range.ts
@@ -26,19 +26,73 @@ import { asObject, asUnsignedLong } from './util/typeHelpers';
  * @public
  */
 export interface AbstractRange {
+	readonly startContainer: Node;
+	readonly startOffset: number;
+	readonly endContainer: Node;
+	readonly endOffset: number;
+	readonly collapsed: boolean;
+}
+
+interface StaticRangeInit {
 	startContainer: Node;
 	startOffset: number;
 	endContainer: Node;
 	endOffset: number;
-	collapsed: boolean;
 }
 
 /**
  * Interface StaticRange
  *
+ * Updating live ranges in response to node tree mutations can be expensive. For every node tree
+ * change, all affected Range objects need to be updated. Even if the application is uninterested in
+ * some live ranges, it still has to pay the cost of keeping them up-to-date when a mutation occurs.
+ *
+ * A StaticRange object is a lightweight range that does not update when the node tree mutates. It
+ * is therefore not subject to the same maintenance cost as live ranges.
+ *
  * @public
  */
-export interface StaticRange extends AbstractRange {}
+export class StaticRange implements AbstractRange {
+	public readonly startContainer: Node;
+	public readonly startOffset: number;
+	public readonly endContainer: Node;
+	public readonly endOffset: number;
+	public readonly collapsed: boolean;
+
+	/**
+	 * The StaticRange(init) constructor, when invoked, must run these steps:
+	 *
+	 * @param init - Dictionary representing the properties to set on the StaticRange
+	 */
+	constructor(init: StaticRangeInit) {
+		// 1. If init’s startContainer or endContainer is a DocumentType or Attr node, then throw an
+		// "InvalidNodeTypeError" DOMException.
+		if (
+			isNodeOfType(init.startContainer, NodeType.DOCUMENT_TYPE_NODE, NodeType.ATTRIBUTE_NODE)
+		) {
+			throwInvalidNodeTypeError(
+				'StaticRange startContainer must not be a doctype or attribute node'
+			);
+		}
+		if (isNodeOfType(init.endContainer, NodeType.DOCUMENT_TYPE_NODE, NodeType.ATTRIBUTE_NODE)) {
+			throwInvalidNodeTypeError(
+				'StaticRange endContainer must not be a doctype or attribute node'
+			);
+		}
+
+		// 2. Let staticRange be a new StaticRange object.
+		// 3. Set staticRange’s start to (init’s startContainer, init’s startOffset) and end to
+		// (init’s endContainer, init’s endOffset).
+		this.startContainer = init.startContainer;
+		this.startOffset = init.startOffset;
+		this.endContainer = init.endContainer;
+		this.endOffset = init.endOffset;
+		this.collapsed =
+			this.startContainer === this.endContainer && this.startOffset === this.endOffset;
+
+		// 4. Return staticRange.
+	}
+}
 
 /**
  * A range is collapsed if its start node is its end node and its start offset is its end offset.
@@ -124,12 +178,12 @@ export default class Range implements AbstractRange {
 
 		// 3. Let bp be the boundary point (node, offset).
 		// 4.a. If these steps were invoked as "set the start"
-		// 4.a.1. If bp is after the range’s end, or if range’s root is not equal to node’s root,
+		// 4.a.1. If range’s root is not equal to node’s root, or if bp is after the range’s end,
 		// set range’s end to bp.
-		const rootOfNode = getRootOfNode(node);
 		const rootOfRange = getRootOfRange(this);
+		const rootOfNode = getRootOfNode(node);
 		if (
-			rootOfNode !== rootOfRange ||
+			rootOfRange !== rootOfNode ||
 			compareBoundaryPointPositions(node, offset, this.endContainer, this.endOffset) ===
 				POSITION_AFTER
 		) {
@@ -141,7 +195,7 @@ export default class Range implements AbstractRange {
 		this.startOffset = offset;
 
 		// 4.b. If these steps were invoked as "set the end"
-		// 4.b.1. If bp is before the range’s start, or if range’s root is not equal to node’s root,
+		// 4.b.1. If range’s root is not equal to node’s root, or if bp is before the range’s start,
 		// set range’s start to bp.
 		// 4.b.2. Set range’s end to bp.
 		// (see Range#setEnd for this branch)
@@ -170,18 +224,18 @@ export default class Range implements AbstractRange {
 
 		// 3. Let bp be the boundary point (node, offset).
 		// 4.a. If these steps were invoked as "set the start"
-		// 4.a.1. If bp is after the range’s end, or if range’s root is not equal to node’s root,
+		// 4.a.1. If range’s root is not equal to node’s root, or if bp is after the range’s end,
 		// set range’s end to bp.
 		// 4.a.2. Set range’s start to bp.
 		// (see Range#setStart for this branch)
 
 		// 4.b. If these steps were invoked as "set the end"
-		// 4.b.1. If bp is before the range’s start, or if range’s root is not equal to node’s root,
+		// 4.b.1. If range’s root is not equal to node’s root, or if bp is before the range’s start,
 		// set range’s start to bp.
-		const rootOfNode = getRootOfNode(node);
 		const rootOfRange = getRootOfRange(this);
+		const rootOfNode = getRootOfNode(node);
 		if (
-			rootOfNode !== rootOfRange ||
+			rootOfRange !== rootOfNode ||
 			compareBoundaryPointPositions(node, offset, this.startContainer, this.startOffset) ===
 				POSITION_BEFORE
 		) {
@@ -210,7 +264,7 @@ export default class Range implements AbstractRange {
 			return throwInvalidNodeTypeError('Can not set range before node without a parent');
 		}
 
-		// 3. Set the start of the context object to boundary point (parent, node’s index).
+		// 3. Set the start of this to boundary point (parent, node’s index).
 		this.setStart(parent, getNodeIndex(node));
 	}
 
@@ -231,7 +285,7 @@ export default class Range implements AbstractRange {
 			return throwInvalidNodeTypeError('Can not set range before node without a parent');
 		}
 
-		// 3. Set the start of the context object to boundary point (parent, node’s index plus one).
+		// 3. Set the start of this to boundary point (parent, node’s index plus one).
 		this.setStart(parent, getNodeIndex(node) + 1);
 	}
 
@@ -252,7 +306,7 @@ export default class Range implements AbstractRange {
 			return throwInvalidNodeTypeError('Can not set range before node without a parent');
 		}
 
-		// 3. Set the end of the context object to boundary point (parent, node’s index).
+		// 3. Set the end of this to boundary point (parent, node’s index).
 		this.setEnd(parent, getNodeIndex(node));
 	}
 
@@ -273,7 +327,7 @@ export default class Range implements AbstractRange {
 			return throwInvalidNodeTypeError('Can not set range before node without a parent');
 		}
 
-		// 3. Set the end of the context object to boundary point (parent, node’s index plus one).
+		// 3. Set the end of this to boundary point (parent, node’s index plus one).
 		this.setEnd(parent, getNodeIndex(node) + 1);
 	}
 
@@ -358,7 +412,7 @@ export default class Range implements AbstractRange {
 			throwNotSupportedError('Unsupported comparison type');
 		}
 
-		// 2. If context object’s root is not the same as sourceRange’s root, then throw a
+		// 2. If this’s root is not the same as sourceRange’s root, then throw a
 		// WrongDocumentError.
 		if (getRootOfRange(this) !== getRootOfRange(sourceRange)) {
 			throwWrongDocumentError('Can not compare positions of ranges in different trees');
@@ -368,7 +422,7 @@ export default class Range implements AbstractRange {
 		switch (how) {
 			// START_TO_START:
 			case Range.START_TO_START:
-				// Let this point be the context object’s start. Let other point be sourceRange’s
+				// Let this point be this’s start. Let other point be sourceRange’s
 				// start.
 				return compareBoundaryPointPositions(
 					// this point
@@ -381,7 +435,7 @@ export default class Range implements AbstractRange {
 
 			// START_TO_END:
 			case Range.START_TO_END:
-				// Let this point be the context object’s end. Let other point be sourceRange’s
+				// Let this point be this’s end. Let other point be sourceRange’s
 				// start.
 				return compareBoundaryPointPositions(
 					// this point
@@ -394,7 +448,7 @@ export default class Range implements AbstractRange {
 
 			// END_TO_END:
 			case Range.END_TO_END:
-				// Let this point be the context object’s end. Let other point be sourceRange’s end.
+				// Let this point be this’s end. Let other point be sourceRange’s end.
 				return compareBoundaryPointPositions(
 					// this point
 					this.endContainer,
@@ -406,7 +460,7 @@ export default class Range implements AbstractRange {
 
 			// END_TO_START:
 			default:
-				// Let this point be the context object’s start. Let other point be sourceRange’s
+				// Let this point be this’s start. Let other point be sourceRange’s
 				// end.
 				return compareBoundaryPointPositions(
 					// this point
@@ -426,9 +480,9 @@ export default class Range implements AbstractRange {
 	}
 
 	/**
-	 * Returns a range with the same start and end as the context object.
+	 * Returns a range with the same start and end as this.
 	 *
-	 * @returns A copy of the context object
+	 * @returns A copy of this
 	 */
 	cloneRange(): Range {
 		const context = getContext(this);
@@ -458,7 +512,7 @@ export default class Range implements AbstractRange {
 
 	/**
 	 * Returns true if the given point is after or equal to the start point and before or equal to
-	 * the end point of the context object.
+	 * the end point of this.
 	 *
 	 * @param node   - Node of point to check
 	 * @param offset - Offset of point to check
@@ -470,7 +524,7 @@ export default class Range implements AbstractRange {
 		node = asObject(node, Node);
 		offset = asUnsignedLong(offset);
 
-		// 1. If node’s root is different from the context object’s root, return false.
+		// 1. If node’s root is different from this’s root, return false.
 		if (getRootOfNode(node) !== getRootOfRange(this)) {
 			return false;
 		}
@@ -513,7 +567,7 @@ export default class Range implements AbstractRange {
 		node = asObject(node, Node);
 		offset = asUnsignedLong(offset);
 
-		// 1. If node’s root is different from the context object’s root, then throw a
+		// 1. If node’s root is different from this’s root, then throw a
 		// WrongDocumentError.
 		if (getRootOfNode(node) !== getRootOfRange(this)) {
 			throwWrongDocumentError('Can not compare point to range in different trees');
@@ -560,7 +614,7 @@ export default class Range implements AbstractRange {
 		expectArity(arguments, 1);
 		node = asObject(node, Node);
 
-		// 1. If node’s root is different from the context object’s root, return false.
+		// 1. If node’s root is different from this’s root, return false.
 		if (getRootOfNode(node) !== getRootOfRange(this)) {
 			return false;
 		}

--- a/src/Text.ts
+++ b/src/Text.ts
@@ -53,11 +53,11 @@ export default class Text extends CharacterData {
 	}
 
 	/**
-	 * (non-standard) Creates a copy of the context object, not including its children.
+	 * (non-standard) Creates a copy of this, not including its children.
 	 *
 	 * @param document - The node document to associate with the copy
 	 *
-	 * @returns A shallow copy of the context object
+	 * @returns A shallow copy of this
 	 */
 	public _copy(document: Document): Text {
 		// Set copy’s data, to that of node.
@@ -70,7 +70,7 @@ export default class Text extends CharacterData {
 	/**
 	 * Returns the combined data of all direct Text node siblings.
 	 *
-	 * @returns the concatenation of the data of the contiguous Text nodes of the context object, in
+	 * @returns the concatenation of the data of the contiguous Text nodes of this, in
 	 *          tree order.
 	 */
 	public get wholeText(): string {
@@ -133,7 +133,7 @@ function splitText(node: Text, offset: number): Text {
 	// 6. Let parent be node’s parent.
 	const parent = node.parentNode;
 
-	// 7. If parent is not null, then:
+	// 7. If parent is non-null, then:
 	if (parent !== null) {
 		// 7.1. Insert new node into parent before node’s next sibling.
 		insertNode(newNode, parent, node.nextSibling);

--- a/src/XMLDocument.ts
+++ b/src/XMLDocument.ts
@@ -6,11 +6,11 @@ import { getContext } from './context/Context';
  */
 export default class XMLDocument extends Document {
 	/**
-	 * (non-standard) Creates a copy of the context object, not including its children.
+	 * (non-standard) Creates a copy of this, not including its children.
 	 *
 	 * @param document - The node document to associate with the copy
 	 *
-	 * @returns A shallow copy of the context object
+	 * @returns A shallow copy of this
 	 */
 	public _copy(document: Document): XMLDocument {
 		// Set copy’s encoding, content type, URL, origin, type, and mode, to those of node.

--- a/src/dom-parsing/NamespacePrefixMap.ts
+++ b/src/dom-parsing/NamespacePrefixMap.ts
@@ -171,7 +171,7 @@ export function recordNamespaceInformation(
 				continue;
 			}
 
-			// 2.3.2. Otherwise, the attribute prefix is not null and attr is a namespace prefix
+			// 2.3.2. Otherwise, the attribute prefix is non-null and attr is a namespace prefix
 			// definition. Run the following steps:
 			// 2.3.2.1. Let prefix definition be the value of attr's localName.
 			const prefixDefinition = attr.localName;

--- a/src/dom-parsing/serializationAlgorithms.ts
+++ b/src/dom-parsing/serializationAlgorithms.ts
@@ -369,7 +369,7 @@ function serializeElementNode(
 
 	// 11. If inherited ns is equal to ns, then:
 	if (inheritedNs === ns) {
-		// 11.1. If local default namespace is not null, then set ignore namespace definition
+		// 11.1. If local default namespace is non-null, then set ignore namespace definition
 		// attribute to true.
 		if (localDefaultNamespace !== null) {
 			ignoreNamespaceDefinitionAttribute = true;
@@ -412,7 +412,7 @@ function serializeElementNode(
 			candidatePrefix = prefix;
 		}
 
-		// 12.4. Found a suitable namespace prefix: if candidate prefix is not null (a namespace
+		// 12.4. Found a suitable namespace prefix: if candidate prefix is non-null (a namespace
 		// prefix is defined which maps to ns), then:
 		if (candidatePrefix !== null) {
 			// NOTE: The following may serialize a different prefix than the Element's existing
@@ -424,7 +424,7 @@ function serializeElementNode(
 			// namespace prefix definition that defines the node's namespace.
 			qualifiedName += candidatePrefix + ':' + element.localName;
 
-			// 12.4.2. If the local default namespace is not null (there exists a locally-defined
+			// 12.4.2. If the local default namespace is non-null (there exists a locally-defined
 			// default namespace declaration attribute) and its value is not the XML namespace, then
 			// let inherited ns get the value of local default namespace unless the local default
 			// namespace is the empty string in which case let it get null (the context namespace is
@@ -438,7 +438,7 @@ function serializeElementNode(
 			// 12.4.3. Append the value of qualified name to markup.
 			result.push(qualifiedName);
 		} else if (prefix !== null) {
-			// 12.5. Otherwise, if prefix is not null, then:
+			// 12.5. Otherwise, if prefix is non-null, then:
 			// NOTE: By this step, there is no namespace or prefix mapping declaration in this node
 			// (or any parent node visited by this algorithm) that defines prefix otherwise the step
 			// labelled Found a suitable namespace prefix would have been followed. The sub-steps
@@ -480,7 +480,7 @@ function serializeElementNode(
 				'"'
 			);
 
-			// 12.5.5.7. If local default namespace is not null (there exists a locally-defined
+			// 12.5.5.7. If local default namespace is non-null (there exists a locally-defined
 			// default namespace declaration attribute), then let inherited ns get the value of
 			// local default namespace unless the local default namespace is the empty string in
 			// which case let it get null.
@@ -492,7 +492,7 @@ function serializeElementNode(
 			(localDefaultNamespace !== null && localDefaultNamespace !== ns)
 		) {
 			// 12.6. Otherwise, if local default namespace is null, or local default namespace is
-			// not null and its value is not equal to ns, then:
+			// non-null and its value is not equal to ns, then:
 			// NOTE: At this point, the namespace for this node still needs to be serialized, but
 			// there's no prefix (or candidate prefix) availble; the following uses the default
 			// namespace declaration to define the namespace --optionally replacing an existing
@@ -678,7 +678,7 @@ function serializeAttributes(
 		// 3.4. Let candidate prefix be null.
 		let candidatePrefix: string | null = null;
 
-		// 3.5. If attribute namespace is not null, then run these sub-steps:
+		// 3.5. If attribute namespace is non-null, then run these sub-steps:
 		if (attributeNamespace !== null) {
 			// 3.5.1. Let candidate prefix be the result of retrieving a preferred prefix string
 			// from map given namespace attribute namespace with preferred prefix being attr's
@@ -705,7 +705,7 @@ function serializeAttributes(
 					continue;
 				}
 
-				// - the attr's prefix is not null and either
+				// - the attr's prefix is non-null and either
 				//   - the attr's localName is not a key contained in the local prefixes map, or
 				//   - the attr's localName is present in the local prefixes map but the value of
 				//     the key does not match attr's value
@@ -807,7 +807,7 @@ function serializeAttributes(
 		// 3.6. Append a " " (U+0020 SPACE) to result.
 		result.push(' ');
 
-		// 3.7. If candidate prefix is not null, then append to result the concatenation of
+		// 3.7. If candidate prefix is non-null, then append to result the concatenation of
 		// candidate prefix with ":" (U+003A COLON).
 		if (candidatePrefix !== null) {
 			result.push(candidatePrefix, ':');

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export { default as Element } from './Element';
 export { default as Node } from './Node';
 export { default as ProcessingInstruction } from './ProcessingInstruction';
 export { default as Range } from './Range';
+export { StaticRange } from './Range';
 export { default as Text } from './Text';
 export { default as XMLDocument } from './XMLDocument';
 export { default as XMLSerializer } from './dom-parsing/XMLSerializer';

--- a/src/mutation-observer/MutationObserver.ts
+++ b/src/mutation-observer/MutationObserver.ts
@@ -157,14 +157,14 @@ export default class MutationObserver {
 		}
 
 		// 7. For each registered registered of target’s registered observer list, if registered's
-		// observer is the context object:
-		// 7.1. For each node of the context object's node list, remove all transient registered
+		// observer is this:
+		// 7.1. For each node of this's node list, remove all transient registered
 		// observers whose source is registered from node's registered observer list.
 		// 7.2. Set registered’s options to options.
 		// 8. Otherwise:
-		// 8.1. Append a new registered observer whose observer is the context object and options is
+		// 8.1. Append a new registered observer whose observer is this and options is
 		// options to target's registered observer list.
-		// 8.2. Append target to the context object's node list.
+		// 8.2. Append target to this's node list.
 		target._registeredObservers.register(this, options);
 	}
 
@@ -173,12 +173,12 @@ export default class MutationObserver {
 	 * observe() method is used again, observer's callback will not be invoked.
 	 */
 	disconnect() {
-		// 1. For each node of the context object’s node list, remove any registered observer from
-		// node's registered observer list for which the context object is the observer.
+		// 1. For each node of this’s node list, remove any registered observer from
+		// node's registered observer list for which this is the observer.
 		this._nodes.forEach((node) => node._registeredObservers.removeForObserver(this));
 		this._nodes.length = 0;
 
-		// 2. Empty the context object’s record queue.
+		// 2. Empty this’s record queue.
 		this._recordQueue.length = 0;
 	}
 
@@ -188,9 +188,9 @@ export default class MutationObserver {
 	 * @returns An Array of MutationRecord objects that were recorded.
 	 */
 	takeRecords(): MutationRecord[] {
-		// 1. Let records be a clone of the context object's record queue.
+		// 1. Let records be a clone of this's record queue.
 		const records = this._recordQueue.concat();
-		// 2. Empty the context object's record queue
+		// 2. Empty this's record queue
 		this._recordQueue.length = 0;
 		// 3. Return records
 		return records;

--- a/src/mutation-observer/RegisteredObserver.ts
+++ b/src/mutation-observer/RegisteredObserver.ts
@@ -37,7 +37,7 @@ export default class RegisteredObserver {
 	 * @param observer - The observer being registered
 	 * @param node     - The node being observed
 	 * @param options  - Options for the registration
-	 * @param source   - If not null, creates a transient registered observer for the given
+	 * @param source   - If non-null, creates a transient registered observer for the given
 	 *                   registered observer
 	 */
 	constructor(

--- a/src/mutation-observer/RegisteredObservers.ts
+++ b/src/mutation-observer/RegisteredObservers.ts
@@ -30,7 +30,7 @@ export default class RegisteredObservers {
 	public register(observer: MutationObserver, options: MutationObserverInit) {
 		// (continuing from MutationObserver#observe)
 		// 7. For each registered registered of target’s registered observer list, if registered's
-		// observer is the context object:
+		// observer is this:
 		const registeredObservers = this._registeredObservers;
 		let hasRegisteredObserverForObserver = false;
 		registeredObservers.forEach((registered) => {
@@ -40,7 +40,7 @@ export default class RegisteredObservers {
 
 			hasRegisteredObserverForObserver = true;
 
-			// 7.1. For each node of the context object's node list, remove all transient registered
+			// 7.1. For each node of this's node list, remove all transient registered
 			// observers whose source is registered from node's registered observer list.
 			removeTransientRegisteredObserversForSource(registered);
 
@@ -50,10 +50,10 @@ export default class RegisteredObservers {
 
 		// 8. Otherwise:
 		if (!hasRegisteredObserverForObserver) {
-			// 8.1. Append a new registered observer whose observer is the context object and
+			// 8.1. Append a new registered observer whose observer is this and
 			// options is options to target's registered observer list.
 			this._registeredObservers.push(new RegisteredObserver(observer, this._node, options));
-			// 8.2. Append target to the context object's node list.
+			// 8.2. Append target to this's node list.
 			observer._nodes.push(this._node);
 		}
 	}

--- a/src/mutation-observer/queueMutationRecord.ts
+++ b/src/mutation-observer/queueMutationRecord.ts
@@ -11,12 +11,10 @@ import Node from '../Node';
  * namespace namespace, oldValue oldValue, addedNodes addedNodes, removedNodes removedNodes,
  *
  * To queue a tree mutation record for target with addedNodes, removedNodes, previousSibling, and
- * nextSibling, queue a mutation record of "childList" for target with null, null, null, addedNodes,
- * removedNodes, previousSibling, and nextSibling.
- *
- * To queue an attribute mutation record for target with name, namespace, and oldValue, queue a
- * mutation record of "attributes" for target with name, namespace, oldValue, « », « », null, and
- * null.
+ * nextSibling, run these steps:
+ *  - Assert: either addedNodes or removedNodes is not empty.
+ *  - Queue a mutation record of "childList" for target with null, null, null, addedNodes,
+ *    removedNodes, previousSibling, and nextSibling.
  *
  * @param type   - The type of mutation record to queue
  * @param target - The target node
@@ -84,6 +82,6 @@ export default function queueMutationRecord(type: string, target: Node, data: Mu
 		context._notifySet.appendRecord(observer, record);
 	});
 
-	// 5. Queue a mutation observer compound microtask.
-	context._notifySet.queueMutationObserverCompoundMicrotask();
+	// 5. Queue a mutation observer microtask.
+	context._notifySet.queueMutationObserverMicrotask();
 }

--- a/src/util/NodeType.ts
+++ b/src/util/NodeType.ts
@@ -5,14 +5,14 @@ export const enum NodeType {
 	ATTRIBUTE_NODE = 2,
 	TEXT_NODE = 3,
 	CDATA_SECTION_NODE = 4,
-	ENTITY_REFERENCE_NODE = 5, // historical
-	ENTITY_NODE = 6, // historical
+	ENTITY_REFERENCE_NODE = 5, // legacy
+	ENTITY_NODE = 6, // legacy
 	PROCESSING_INSTRUCTION_NODE = 7,
 	COMMENT_NODE = 8,
 	DOCUMENT_NODE = 9,
 	DOCUMENT_TYPE_NODE = 10,
 	DOCUMENT_FRAGMENT_NODE = 11,
-	NOTATION_NODE = 12, // historical
+	NOTATION_NODE = 12, // legacy
 }
 
 /**

--- a/src/util/attrMutations.ts
+++ b/src/util/attrMutations.ts
@@ -3,19 +3,26 @@ import Element from '../Element';
 import queueMutationRecord from '../mutation-observer/queueMutationRecord';
 
 /**
- * To change an attribute attribute from an element element to value, run these steps:
+ * To handle attribute changes for an attribute attribute with element, oldValue, and newValue, run
+ * these steps:
  *
- * @param attribute - The attribute to change
+ * @param attribute - The attribute that is being changed
  * @param element   - The element that has the attribute
- * @param value     - The new value for the attribute
+ * @param oldValue  - The old value for the attribute
+ * @param newValue  - The new value for the attribute
  */
-export function changeAttribute(attribute: Attr, element: Element, value: string): void {
-	// 1. Queue an attribute mutation record for element with attribute’s local name, attribute's
-	// namespace, and attribute’s value.
+export function handleAttributeChanges(
+	attribute: Attr,
+	element: Element,
+	oldValue: string | null,
+	newValue: string | null
+): void {
+	// 1. Queue a mutation record of "attributes" for element with attribute’s local name,
+	// attribute's namespace, oldValue, « », « », null, and null.
 	queueMutationRecord('attributes', element, {
 		name: attribute.localName,
 		namespace: attribute.namespaceURI,
-		oldValue: attribute.value,
+		oldValue,
 	});
 
 	// 2. If element is custom, then enqueue a custom element callback reaction with element,
@@ -23,11 +30,23 @@ export function changeAttribute(attribute: Attr, element: Element, value: string
 	// name, attribute’s value, value, and attribute’s namespace.
 	// (custom elements not implemented)
 
-	// 3. Run the attribute change steps with element, attribute’s local name, attribute’s value,
-	// value, and attribute’s namespace.
+	// 3. Run the attribute change steps with element, attribute’s local name, oldValue, newValue,
+	// and attribute’s namespace.
 	// (attribute change steps not implemented)
+}
 
-	// 4. Set attribute’s value to value.
+/**
+ * To change an attribute attribute to value, run these steps:
+ *
+ * @param attribute - The attribute to change
+ * @param value     - The new value for the attribute
+ */
+export function changeAttribute(attribute: Attr, value: string): void {
+	// 1. Handle attribute changes for attribute with attribute’s element, attribute’s value, and
+	// value.
+	handleAttributeChanges(attribute, attribute.ownerElement!, attribute.value, value);
+
+	// 2. Set attribute’s value to value.
 	(attribute as any)._value = value;
 }
 
@@ -38,92 +57,52 @@ export function changeAttribute(attribute: Attr, element: Element, value: string
  * @param element   - The element to append attribute to
  */
 export function appendAttribute(attribute: Attr, element: Element): void {
-	// 1. Queue an attribute mutation record for element with attribute’s local name, attribute's
-	// namespace, and null.
-	queueMutationRecord('attributes', element, {
-		name: attribute.localName,
-		namespace: attribute.namespaceURI,
-		oldValue: null,
-	});
+	// 1. Handle attribute changes for attribute with element, null and attribute's value.
+	handleAttributeChanges(attribute, element, null, attribute.value);
 
-	// 2. If element is custom, then enqueue a custom element callback reaction with element,
-	// callback name "attributeChangedCallback", and an argument list containing attribute’s local
-	// name, null, attribute’s value, and attribute’s namespace.
-	// (custom elements not implemented)
-
-	// 3. Run the attribute change steps with element, attribute’s local name, null, attribute’s
-	// value, and attribute’s namespace.
-	// (attribute change steps not implemented)
-
-	// 4. Append attribute to element’s attribute list.
+	// 2. Append attribute to element’s attribute list.
 	element.attributes.push(attribute);
 
-	// 5. Set attribute’s element to element.
+	// 3. Set attribute’s element to element.
 	attribute.ownerElement = element;
 }
 
 /**
- * To remove an attribute attribute from an element element, run these steps:
+ * To remove an attribute attribute, run these steps:
  *
  * @param attribute - The attribute to remove
- * @param element   - The element to remove attribute from
  */
-export function removeAttribute(attribute: Attr, element: Element): void {
-	// 1. Queue an attribute mutation record for element with attribute’s local name, attribute's
-	// namespace, and attribute’s value.
-	queueMutationRecord('attributes', element, {
-		name: attribute.localName,
-		namespace: attribute.namespaceURI,
-		oldValue: attribute.value,
-	});
+export function removeAttribute(attribute: Attr): void {
+	const attributeElement = attribute.ownerElement!;
+	// 1. Handle attribute changes for attribute with attribute’s element, attribute’s value, and
+	// null.
+	handleAttributeChanges(attribute, attributeElement, attribute.value, null);
 
-	// 2. If element is custom, then enqueue a custom element callback reaction with element,
-	// callback name "attributeChangedCallback", and an argument list containing attribute’s local
-	// name, attribute’s value, null, and attribute’s namespace.
-	// (custom elements not implemented)
+	// 2. Remove attribute from attribute's element’s attribute list.
+	attributeElement.attributes.splice(attributeElement.attributes.indexOf(attribute), 1);
 
-	// 3. Run the attribute change steps with element, attribute’s local name, attribute’s value,
-	// null, and attribute’s namespace.
-	// (attribute change steps not implemented)
-
-	// 4. Remove attribute from element’s attribute list.
-	element.attributes.splice(element.attributes.indexOf(attribute), 1);
-
-	// 5. Set attribute’s element to null.
+	// 3. Set attribute’s element to null.
 	attribute.ownerElement = null;
 }
 
 /**
- * To replace an attribute oldAttr by an attribute newAttr in an element element, run these steps:
+ * To replace an attribute oldAttr with an attribute newAttr, run these steps:
  *
  * @param oldAttr - The attribute to replace
  * @param newAttr - The attribute to replace oldAttr with
- * @param element - The element on which to replace the attribute
  */
-export function replaceAttribute(oldAttr: Attr, newAttr: Attr, element: Element): void {
-	// 1. Queue an attribute mutation record for element with oldAttr’s local name, oldAttr’s
-	// namespace, and oldAttr’s value.
-	queueMutationRecord('attributes', element, {
-		name: oldAttr.localName,
-		namespace: oldAttr.namespaceURI,
-		oldValue: oldAttr.value,
-	});
-
-	// 2. If element is custom, then enqueue a custom element callback reaction with element,
-	// callback name "attributeChangedCallback", and an argument list containing oldAttr’s local
-	// name, oldAttr’s value, newAttr’s value, and oldAttr’s namespace.
-	// (custom elements not implemented)
-
-	// 3. Run the attribute change steps with element, oldAttr’s local name, oldAttr’s value,
-	// newAttr’s value, and oldAttr’s namespace.
-	// (attribute change steps not implemented)
+export function replaceAttribute(oldAttr: Attr, newAttr: Attr): void {
+	const oldAttrElement = oldAttr.ownerElement!;
+	// 1. Handle attribute changes for oldAttr with oldAttr’s element, oldAttr’s value,
+	// and newAttr’s value.
+	handleAttributeChanges(oldAttr, oldAttrElement, oldAttr.value, newAttr.value);
 
 	// 4. Replace oldAttr by newAttr in element’s attribute list.
-	element.attributes.splice(element.attributes.indexOf(oldAttr), 1, newAttr);
+	oldAttrElement.attributes.splice(oldAttrElement.attributes.indexOf(oldAttr), 1, newAttr);
 
-	// 5. Set oldAttr’s element to null.
+	// 5. Set newAttr’s element to oldAttr's element.
+	newAttr.ownerElement = oldAttrElement;
+
+	// 6. Set oldAttr’s element to null.
 	oldAttr.ownerElement = null;
-
-	// 6. Set newAttr’s element to element.
-	newAttr.ownerElement = element;
 }

--- a/src/util/mutationAlgorithms.ts
+++ b/src/util/mutationAlgorithms.ts
@@ -40,7 +40,7 @@ function ensurePreInsertionValidity(node: Node, parent: Node, child: Node | null
 		throwHierarchyRequestError('node must not be an inclusive ancestor of parent');
 	}
 
-	// 3. If child is not null and its parent is not parent, then throw a NotFoundError.
+	// 3. If child is non-null and its parent is not parent, then throw a NotFoundError.
 	if (child && child.parentNode !== parent) {
 		throwNotFoundError('child is not a child of parent');
 	}
@@ -99,7 +99,7 @@ function ensurePreInsertionValidity(node: Node, parent: Node, child: Node | null
 					throwHierarchyRequestError('can not insert a Text node under a Document');
 				}
 				// Otherwise, if node has one element child and either parent has an element child,
-				// child is a doctype, or child is not null and a doctype is following child.
+				// child is a doctype, or child is non-null and a doctype is following child.
 				if (
 					fragment.firstElementChild &&
 					(parentDocument.documentElement ||
@@ -117,7 +117,7 @@ function ensurePreInsertionValidity(node: Node, parent: Node, child: Node | null
 
 			// element
 			case NodeType.ELEMENT_NODE:
-				// parent has an element child, child is a doctype, or child is not null and a
+				// parent has an element child, child is a doctype, or child is non-null and a
 				// doctype is following child.
 				if (
 					parentDocument.documentElement ||
@@ -171,21 +171,18 @@ export function preInsertNode<TNode extends Node>(
 	// 1. Ensure pre-insertion validity of node into parent before child.
 	ensurePreInsertionValidity(node, parent, child);
 
-	// 2. Let reference child be child.
+	// 2. Let referenceChild be child.
 	let referenceChild = child;
 
-	// 3. If reference child is node, set it to node’s next sibling.
+	// 3. If referenceChild is node, set it to node’s next sibling.
 	if (referenceChild === node) {
 		referenceChild = node.nextSibling;
 	}
 
-	// 4. Adopt node into parent’s node document.
-	adoptNode(node, getNodeDocument(parent));
-
-	// 5. Insert node into parent before reference child.
+	// 4. Insert node into parent before referenceChild.
 	insertNode(node, parent, referenceChild);
 
-	// 6. Return node.
+	// 5. Return node.
 	return node;
 }
 
@@ -204,12 +201,31 @@ export function insertNode(
 	child: Node | null,
 	suppressObservers: boolean = false
 ): void {
-	// 1. Let count be the number of children of node if it is a DocumentFragment node, and one
-	// otherwise.
+	// 1. Let nodes be node’s children if node is a DocumentFragment node; otherwise « node ».
 	const isDocumentFragment = isNodeOfType(node, NodeType.DOCUMENT_FRAGMENT_NODE);
-	const count = isDocumentFragment ? determineLengthOfNode(node) : 1;
+	const nodes = isDocumentFragment ? Array.from(node.childNodes) : [node];
 
-	// 2. If child is non-null, then:
+	// 2. Let count be nodes's size.
+	const count = nodes.length;
+
+	// 3. If count is 0, then return.
+	if (count === 0) {
+		return;
+	}
+
+	// 4. If node is a DocumentFragment node, then:
+	if (isDocumentFragment) {
+		// 4.1 Remove its children with the suppress observers flag set.
+		nodes.forEach((n) => removeNode(n, true));
+
+		// 4.2 Queue a tree mutation record for node with « », nodes, null, and null.
+		// Note: This step intentionally does not pay attention to the suppress observers flag.
+		queueMutationRecord('childList', node, {
+			removedNodes: nodes,
+		});
+	}
+
+	// 5. If child is non-null, then:
 	if (child !== null) {
 		const childIndex = getNodeIndex(child);
 		const context = getContext(node);
@@ -228,43 +244,31 @@ export function insertNode(
 		});
 	}
 
-	// 3. Let nodes be node’s children if node is a DocumentFragment node, and a list containing
-	// solely node otherwise.
-	const nodes = isDocumentFragment ? Array.from(node.childNodes) : [node];
-
-	// 4. If node is a DocumentFragment node, remove its children with the suppress observers flag
-	// set.
-	if (isDocumentFragment) {
-		nodes.forEach((n) => removeNode(n, node, true));
-	}
-
-	// 5. If node is a DocumentFragment node, then queue a tree mutation record for node with « »,
-	// nodes, null and null. This step intentionally does not pay attention to the suppress
-	// observers flag.
-	if (isDocumentFragment) {
-		queueMutationRecord('childList', node, {
-			removedNodes: nodes,
-		});
-	}
-
 	// 6. Let previousSibling be child’s previous sibling or parent’s last child if child is null.
-	const previousSibling = child === null ? parent.lastChild : child.previousSibling;
+	let previousSibling = child === null ? parent.lastChild : child.previousSibling;
+
+	// Non-standard: it appears the standard as of 27 January 2021 does not account for
+	// previousSibling now possibly being node, which can happen, for instance, when doing
+	// parent.insertBefore(child, child);
+	if (previousSibling === node) {
+		previousSibling = node.previousSibling;
+	}
 
 	// 7. For each node in nodes, in tree order:
 	nodes.forEach((node) => {
-		// 7.1. If child is null, then append node to parent’s children.
-		// 7.2. Otherwise, insert node into parent’s children before child’s index.
+		// 7.1. Adopt node into parent's node document.
+		adoptNode(node, getNodeDocument(parent));
+
+		// 7.2. If child is null, then append node to parent’s children.
+		// 7.3. Otherwise, insert node into parent’s children before child’s index.
 		insertIntoChildren(node, parent, child);
 
-		// 7.3. If parent is a shadow host and node is a slotable, then assign a slot for node.
+		// 7.4. If parent is a shadow host and node is a slottable, then assign a slot for node.
 		// (shadow dom not implemented)
-
-		// 7.4. If node is a Text node, run the child text content change steps for parent.
-		// (child text content change steps not implemented)
 
 		// 7.5. If parent's root is a shadow root, and parent is a slot whose assigned nodes is the
 		// empty list, then run signal a slot change for parent.
-		// 7.6. Run assign slotables for a tree with node’s tree.
+		// 7.6. Run assign slottables for a tree with node’s tree.
 		// (shadow dom not implemented)
 
 		// 7.7. For each shadow-including inclusive descendant inclusiveDescendant of node, in
@@ -291,6 +295,9 @@ export function insertNode(
 			previousSibling: previousSibling,
 		});
 	}
+
+	// 9. Run the children changed steps for parent
+	// (children changed steps not implemented)
 }
 
 /**
@@ -447,10 +454,10 @@ export function replaceChildWithNode<TChild extends Node>(
 		// The above statements differ from the pre-insert algorithm.
 	}
 
-	// 7. Let reference child be child’s next sibling.
+	// 7. Let referenceChild be child’s next sibling.
 	let referenceChild = child.nextSibling;
 
-	// 8. If reference child is node, set it to node’s next sibling.
+	// 8. If referenceChild is node, set it to node’s next sibling.
 	if (referenceChild === node) {
 		referenceChild = node.nextSibling;
 	}
@@ -458,33 +465,31 @@ export function replaceChildWithNode<TChild extends Node>(
 	// 9. Let previousSibling be child’s previous sibling.
 	const previousSibling = child.previousSibling;
 
-	// 10. Adopt node into parent’s node document.
-	adoptNode(node, getNodeDocument(parent));
-
-	// 11. Let removedNodes be the empty list.
+	// 10. Let removedNodes be the empty set.
 	let removedNodes: Node[] = [];
 
-	// 12. If child’s parent is not null, then:
+	// 11. If child’s parent is non-null, then:
+	/* istanbul ignore else */
 	if (child.parentNode !== null) {
-		// 12.1. Set removedNodes to a list solely containing child.
+		// 11.1. Set removedNodes to « child ».
 		removedNodes.push(child);
 
-		// 12.2. Remove child from its parent with the suppress observers flag set.
-		removeNode(child, child.parentNode, true);
+		// 11.2. Remove child with the suppress observers flag set.
+		removeNode(child, true);
 	}
 	// The above can only be false if child is node.
+	// (TODO: this is no longer the case, at least until whatwg/dom#819 is merged)
 
-	// 13. Let nodes be node’s children if node is a DocumentFragment node, and a list containing
-	// solely node otherwise.
+	// 12. Let nodes be node’s children if node is a DocumentFragment node; otherwise « node ».
 	const nodes = isNodeOfType(node, NodeType.DOCUMENT_FRAGMENT_NODE)
 		? Array.from(node.childNodes)
 		: [node];
 
-	// 14. Insert node into parent before reference child with the suppress observers flag set.
+	// 13. Insert node into parent before referenceChild with the suppress observers flag set.
 	insertNode(node, parent, referenceChild, true);
 
-	// 15. Queue a tree mutation record for parent with nodes, removedNodes, previousSibling and
-	// reference child.
+	// 14. Queue a tree mutation record for parent with nodes, removedNodes, previousSibling and
+	// referenceChild.
 	queueMutationRecord('childList', parent, {
 		addedNodes: nodes,
 		removedNodes: removedNodes,
@@ -492,7 +497,7 @@ export function replaceChildWithNode<TChild extends Node>(
 		previousSibling: previousSibling,
 	});
 
-	// 16. Return child.
+	// 15. Return child.
 	return child;
 }
 
@@ -503,46 +508,43 @@ export function replaceChildWithNode<TChild extends Node>(
  * @param parent Parent to replace under
  */
 function replaceAllWithNode(node: Node | null, parent: Node): void {
-	// 1. If node is not null, adopt node into parent’s node document.
-	if (node !== null) {
-		adoptNode(node, getNodeDocument(parent));
-	}
-
-	// 2. Let removedNodes be parent’s children.
+	// 1. Let removedNodes be parent’s children.
 	const removedNodes = Array.from(parent.childNodes);
 
-	// 3. Let addedNodes be the empty list if node is null, node’s children if node is a
-	// DocumentFragment node, and a list containing node otherwise.
-	let addedNodes: Node[];
-	if (node === null) {
-		addedNodes = [];
-	} else {
-		/* istanbul ignore if */
+	// 2. Let addedNodes be the empty set.
+	let addedNodes: Node[] = [];
+
+	if (node !== null) {
+		// 3. If node is a DocumentFragment node, then set addedNodes to node's children.
 		if (isNodeOfType(node, NodeType.DOCUMENT_FRAGMENT_NODE)) {
-			// This case is never actually reachable from any usage of "replace all" in the spec, as the
-			// algorithm is currently only used with node being either null or a Text instance.
-			addedNodes = Array.from(node.childNodes);
+			node.childNodes.forEach((child) => {
+				addedNodes.push(child);
+			});
 		} else {
-			addedNodes = [];
+			// 4. Otherwise, if node is non-null, set addedNodes to « node ».
+			addedNodes.push(node);
 		}
 	}
 
-	// 4. Remove all parent’s children, in tree order, with the suppress observers flag set.
+	// 5. Remove all parent’s children, in tree order, with the suppress observers flag set.
 	removedNodes.forEach((child) => {
-		removeNode(child, parent, true);
+		removeNode(child, true);
 	});
 
-	// 5. If node is not null, then insert node into parent before null with the suppress observers
+	// 6. If node is non-null, then insert node into parent before null with the suppress observers
 	// flag set.
 	if (node !== null) {
 		insertNode(node, parent, null, true);
 	}
 
-	// 6. Queue a tree mutation record for parent with addedNodes, removedNodes, null, and null.
-	queueMutationRecord('childList', parent, {
-		addedNodes,
-		removedNodes,
-	});
+	// 7. If either addedNodes or removedNodes is not empty, then queue a tree mutation record for
+	// parent with addedNodes, removedNodes, null, and null.
+	if (addedNodes.length > 0 || removedNodes.length > 0) {
+		queueMutationRecord('childList', parent, {
+			addedNodes,
+			removedNodes,
+		});
+	}
 
 	// This algorithm does not make any checks with regards to the node tree constraints.
 	// Specification authors need to use it wisely.
@@ -562,97 +564,102 @@ export function preRemoveChild<TChild extends Node>(child: TChild, parent: Node)
 		throwNotFoundError('child is not a child of parent');
 	}
 
-	// 2. Remove child from parent.
-	removeNode(child, parent);
+	// 2. Remove child.
+	removeNode(child);
 
 	// 3. Return child.
 	return child;
 }
 
 /**
- * To remove a node from a parent, with an optional suppress observers flag, run these steps:
+ * To remove a node, with an optional suppress observers flag, run these steps:
  *
  * @param node              - Child to remove
- * @param parent            - Parent to remove child from
  * @param suppressObservers - Whether to skip enqueueing a mutation record for this mutation
  */
-export function removeNode(node: Node, parent: Node, suppressObservers: boolean = false): void {
-	// 1. Let index be node’s index.
+export function removeNode(node: Node, suppressObservers: boolean = false): void {
+	// 1. Let parent be node's parent
+	// 2. Assert: parent is non-null.
+	const parent = node.parentNode!;
+
+	// 3. Let index be node’s index.
 	const index = getNodeIndex(node);
 
 	const context = getContext(node);
 	context._ranges.forEach((range) => {
-		// 2. For each live range whose start node is an inclusive descendant of node, set its start
+		// 4. For each live range whose start node is an inclusive descendant of node, set its start
 		// to (parent, index).
 		if (node.contains(range.startContainer)) {
 			range.startContainer = parent;
 			range.startOffset = index;
 		}
 
-		// 3. For each live range whose end node is an inclusive descendant of node, set its end to
+		// 5. For each live range whose end node is an inclusive descendant of node, set its end to
 		// (parent, index).
 		if (node.contains(range.endContainer)) {
 			range.endContainer = parent;
 			range.endOffset = index;
 		}
 
-		// 4. For each live range whose start node is parent and start offset is greater than index,
+		// 6. For each live range whose start node is parent and start offset is greater than index,
 		// decrease its start offset by one.
 		if (range.startContainer === parent && range.startOffset > index) {
 			range.startOffset -= 1;
 		}
 
-		// 5. For each live range whose end node is parent and end offset is greater than index,
+		// 7. For each live range whose end node is parent and end offset is greater than index,
 		// decrease its end offset by one.
 		if (range.endContainer === parent && range.endOffset > index) {
 			range.endOffset -= 1;
 		}
 	});
 
-	// 6. For each NodeIterator object iterator whose root’s node document is node’s node document,
+	// 8. For each NodeIterator object iterator whose root’s node document is node’s node document,
 	// run the NodeIterator pre-removing steps given node and iterator.
 	// (NodeIterator not implemented)
 
-	// 7. Let oldPreviousSibling be node’s previous sibling.
+	// 9. Let oldPreviousSibling be node’s previous sibling.
 	const oldPreviousSibling = node.previousSibling;
 
-	// 8. Let oldNextSibling be node’s next sibling.
+	// 10. Let oldNextSibling be node’s next sibling.
 	const oldNextSibling = node.nextSibling;
 
-	// 9. Remove node from its parent’s children.
+	// 11. Remove node from its parent’s children.
 	removeFromChildren(node, parent);
 
-	// 10. If node is assigned, then run assign slotables for node’s assigned slot.
+	// 12. If node is assigned, then run assign slottables for node’s assigned slot.
 	// (shadow dom not implemented)
 
-	// 11. If parent's root is a shadow root, and parent is a slot whose assigned nodes is the empty
+	// 13. If parent's root is a shadow root, and parent is a slot whose assigned nodes is the empty
 	// list, then run signal a slot change for parent.
 	// (shadow dom not implemented)
 
-	// 12. If node has an inclusive descendant that is a slot, then:
-	// 12.1. Run assign slotables for a tree with parent’s tree.
-	// 12.2. Run assign slotables for a tree with node’s tree.
+	// 14. If node has an inclusive descendant that is a slot, then:
+	// 14.1. Run assign slottables for a tree with parent’s tree.
+	// 14.2. Run assign slottables for a tree with node’s tree.
 	// (shadow dom not implemented)
 
-	// 13. Run the removing steps with node and parent.
+	// 15. Run the removing steps with node and parent.
 	// (removing steps not implemented)
 
-	// 14. If node is custom, then enqueue a custom element callback reaction with node, callback
-	// name "disconnectedCallback", and an empty argument list.
+	// 16. Let isParentConnected be parent's connected.
+	// 17. If node is custom and isParentConnected is true, then enqueue a custom element callback
+	// reaction with node, callback name "disconnectedCallback", and an empty argument list.
 	// It is intentional for now that custom elements do not get parent passed. This might change in
 	// the future if there is a need.
 	// (custom elements not implemented)
 
-	// 15. For each shadow-including descendant descendant of node, in shadow-including tree order,
+	// 18. For each shadow-including descendant descendant of node, in shadow-including tree order,
 	// then:
-	// 15.1. Run the removing steps with descendant.
+	// 18.1. Run the removing steps with descendant.
 	// (shadow dom not implemented)
 
-	// 15.2. If descendant is custom, then enqueue a custom element callback reaction with
-	// descendant, callback name "disconnectedCallback", and an empty argument list.
+	// 18.2. If descendant is custom and isParentConnected is true, then enqueue a custom element
+	// callback reaction with descendant, callback name "disconnectedCallback", and an empty
+	// argument list.
 	// (custom elements not implemented)
 
-	// 16. For each inclusive ancestor inclusiveAncestor of parent, and then for each registered of
+	// 19. For each inclusive ancestor inclusiveAncestor of parent, and then for each registered of
 	// inclusiveAncestor's registered observer list, if registered's options's subtree is true, then
 	// append a new transient registered observer whose observer is registered's observer, options
 	// is registered's options, and source is registered to node's registered observer list.
@@ -664,7 +671,7 @@ export function removeNode(node: Node, parent: Node, suppressObservers: boolean 
 		inclusiveAncestor._registeredObservers.appendTransientRegisteredObservers(node);
 	}
 
-	// 17. If suppress observers flag is unset, queue a tree mutation record for parent with « »,
+	// 20. If suppress observers flag is unset, queue a tree mutation record for parent with « »,
 	// « node », oldPreviousSibling, and oldNextSibling
 	if (!suppressObservers) {
 		queueMutationRecord('childList', parent, {
@@ -674,8 +681,8 @@ export function removeNode(node: Node, parent: Node, suppressObservers: boolean 
 		});
 	}
 
-	// 18. If node is a Text node, then run the child text content change steps for parent.
-	// (child text content change steps not implemented)
+	// 21. Run the children changed steps for parent
+	// (children changed steps not implemented)
 }
 
 /**
@@ -690,9 +697,9 @@ export function adoptNode(node: Node, document: Document): void {
 	// 1. Let oldDocument be node’s node document.
 	const oldDocument = getNodeDocument(node);
 
-	// 2. If node’s parent is not null, remove node from its parent.
+	// 2. If node’s parent is non-null, remove node.
 	if (node.parentNode) {
-		removeNode(node, node.parentNode);
+		removeNode(node);
 	}
 
 	// 3. If document is not oldDocument, then:
@@ -726,14 +733,15 @@ export function adoptNode(node: Node, document: Document): void {
 }
 
 /**
- * Implementation of the textContent getter for DocumentFragment and Element.
+ * The descendant text content of a node node is the concatenation of the data of all the Text node
+ * descendants of node, in tree order.
  *
  * @param node Root node
  *
  * @returns  The concatenation of data of all the Text node descendants of the given node, in tree
  *           order
  */
-export function getConcatenatedTextNodesData(node: Node): string {
+export function getDescendantTextContent(node: Node): string {
 	const data: string[] = [];
 	forEachInclusiveDescendant(node, (descendant) => {
 		// CDATASection is a subtype of Text
@@ -749,22 +757,22 @@ export function getConcatenatedTextNodesData(node: Node): string {
 /**
  * Implementation of the textContent setter for DocumentFragment and Element
  *
- * @param contextObject Node for which to set textContent
- * @param newValue      New textContent value
+ * @param parent    Node for which to set textContent
+ * @param newValue  New textContent value
  */
-export function setTextContentByReplacing(contextObject: Node, newValue: string): void {
+export function stringReplaceAll(parent: Node, newValue: string): void {
 	// 1. Let node be null.
 	let node = null;
 
-	// 2. If the given value is not the empty string, set node to a new Text node whose data is the
-	// given value and node document is context object’s node document.
+	// 2. If the given value is not the empty string, then set node to a new Text node whose data is
+	// the given value and node document is parent’s node document.
 	if (newValue !== '') {
-		const context = getContext(contextObject);
+		const context = getContext(parent);
 		node = new context.Text(newValue);
 	}
 
-	// 3. Replace all with node within the context object.
-	replaceAllWithNode(node, contextObject);
+	// 3. Replace all with node within the this.
+	replaceAllWithNode(node, parent);
 }
 
 /**
@@ -808,58 +816,76 @@ function convertNodesIntoNode(nodes: (Node | string)[], document: Document): Nod
 /**
  * The prepend(nodes) method, when invoked, must run these steps:
  *
- * @param contextObject The ParentNode on which the method is invoked
- * @param nodes         The nodes (and/or strings) to prepend
+ * @param thisObject - The ParentNode on which the method is invoked
+ * @param nodes      - The nodes (and/or strings) to prepend
  */
-export function prependNodes(contextObject: Node & ParentNode, nodes: (Node | string)[]): void {
-	// 1. Let node be the result of converting nodes into a node given nodes and context object’s
-	// node document.
-	const node = convertNodesIntoNode(nodes, getNodeDocument(contextObject));
+export function prependNodes(thisObject: Node & ParentNode, nodes: (Node | string)[]): void {
+	// 1. Let node be the result of converting nodes into a node given nodes and this’s node
+	// document.
+	const node = convertNodesIntoNode(nodes, getNodeDocument(thisObject));
 
-	// 2. Pre-insert node into context object before the context object’s first child.
-	preInsertNode(node, contextObject, contextObject.firstChild);
+	// 2. Pre-insert node into this before the this’s first child.
+	preInsertNode(node, thisObject, thisObject.firstChild);
 }
 
 /**
  * The append(nodes) method, when invoked, must run these steps:
  *
- * @param contextObject The ParentNode on which the method is invoked
- * @param nodes         The nodes (and/or strings) to append
+ * @param thisObject - The ParentNode on which the method is invoked
+ * @param nodes      - The nodes (and/or strings) to append
  */
-export function appendNodes(contextObject: Node & ParentNode, nodes: (Node | string)[]): void {
-	// 1. Let node be the result of converting nodes into a node given nodes and context object’s
-	// node document.
-	const node = convertNodesIntoNode(nodes, getNodeDocument(contextObject));
+export function appendNodes(thisObject: Node & ParentNode, nodes: (Node | string)[]): void {
+	// 1. Let node be the result of converting nodes into a node given nodes and this’s node
+	// document.
+	const node = convertNodesIntoNode(nodes, getNodeDocument(thisObject));
 
-	// 2. Append node to context object
-	appendNode(node, contextObject);
+	// 2. Append node to this
+	appendNode(node, thisObject);
+}
+
+/**
+ * The replaceChildren(nodes) method, when invoked, must run these steps:
+ *
+ * @param thisObject - The ParentNode on which the method is invoked
+ * @param nodes      - The nodes (and/or strings) to replace the children with
+ */
+export function replaceChildren(thisObject: Node & ParentNode, nodes: (Node | string)[]): void {
+	// 1. Let node be the result of converting nodes into a node given nodes and this's node
+	// document.
+	const node = convertNodesIntoNode(nodes, getNodeDocument(thisObject));
+
+	// 2. Ensure pre-insertion validity of node into this before null.
+	ensurePreInsertionValidity(node, thisObject, null);
+
+	// 3. Replace all with node within this.
+	replaceAllWithNode(node, thisObject);
 }
 
 /**
  * The before(nodes) method, when invoked, must run these steps:
  *
- * @param contextObject The ChildNode on which the method is invoked
- * @param nodes         The nodes (and/or strings) to insert
+ * @param thisObject - The ChildNode on which the method is invoked
+ * @param nodes        The nodes (and/or strings) to insert
  */
-export function insertNodesBefore(contextObject: Node & ChildNode, nodes: (Node | string)[]): void {
-	// 1. Let parent be context object’s parent.
-	const parent = contextObject.parentNode;
+export function insertNodesBefore(thisObject: Node & ChildNode, nodes: (Node | string)[]): void {
+	// 1. Let parent be this’s parent.
+	const parent = thisObject.parentNode;
 
 	// 2. If parent is null, then return.
 	if (parent === null) {
 		return;
 	}
 
-	// 3. Let viablePreviousSibling be context object’s first preceding sibling not in nodes, and
+	// 3. Let viablePreviousSibling be this’s first preceding sibling not in nodes, and
 	// null otherwise.
-	let viablePreviousSibling = contextObject.previousSibling;
+	let viablePreviousSibling = thisObject.previousSibling;
 	while (viablePreviousSibling !== null && nodes.indexOf(viablePreviousSibling) >= 0) {
 		viablePreviousSibling = viablePreviousSibling.previousSibling;
 	}
 
-	// 4. Let node be the result of converting nodes into a node, given nodes and context object’s
+	// 4. Let node be the result of converting nodes into a node, given nodes and this’s
 	// node document.
-	const node = convertNodesIntoNode(nodes, getNodeDocument(contextObject));
+	const node = convertNodesIntoNode(nodes, getNodeDocument(thisObject));
 
 	// 5. If viablePreviousSibling is null, set it to parent’s first child, and to
 	// viablePreviousSibling’s next sibling otherwise.
@@ -875,28 +901,28 @@ export function insertNodesBefore(contextObject: Node & ChildNode, nodes: (Node 
 /**
  * The after(nodes) method, when invoked, must run these steps:
  *
- * @param contextObject The ChildNode on which the method is invoked
- * @param nodes         The nodes (and/or strings) to insert
+ * @param thisObject - The ChildNode on which the method is invoked
+ * @param nodes      - The nodes (and/or strings) to insert
  */
-export function insertNodesAfter(contextObject: Node & ChildNode, nodes: (Node | string)[]): void {
-	// 1. Let parent be context object’s parent.
-	const parent = contextObject.parentNode;
+export function insertNodesAfter(thisObject: Node & ChildNode, nodes: (Node | string)[]): void {
+	// 1. Let parent be this’s parent.
+	const parent = thisObject.parentNode;
 
 	// 2. If parent is null, then return.
 	if (parent === null) {
 		return;
 	}
 
-	// 3. Let viableNextSibling be context object’s first following sibling not in nodes, and null
+	// 3. Let viableNextSibling be this’s first following sibling not in nodes, and null
 	// otherwise.
-	let viableNextSibling = contextObject.nextSibling;
+	let viableNextSibling = thisObject.nextSibling;
 	while (viableNextSibling !== null && nodes.indexOf(viableNextSibling) >= 0) {
 		viableNextSibling = viableNextSibling.nextSibling;
 	}
 
-	// 4. Let node be the result of converting nodes into a node, given nodes and context object’s
+	// 4. Let node be the result of converting nodes into a node, given nodes and this’s
 	// node document.
-	const node = convertNodesIntoNode(nodes, getNodeDocument(contextObject));
+	const node = convertNodesIntoNode(nodes, getNodeDocument(thisObject));
 
 	// 5. Pre-insert node into parent before viableNextSibling.
 	preInsertNode(node, parent, viableNextSibling);
@@ -905,33 +931,33 @@ export function insertNodesAfter(contextObject: Node & ChildNode, nodes: (Node |
 /**
  * The replaceWith(nodes) method, when invoked, must run these steps:
  *
- * @param contextObject The ChildNode on which the method is invoked
- * @param nodes         The nodes (and/or strings) to insert
+ * @param thisObject - The ChildNode on which the method is invoked
+ * @param nodes      - The nodes (and/or strings) to insert
  */
-export function replaceWithNodes(contextObject: Node & ChildNode, nodes: (Node | string)[]): void {
-	// 1. Let parent be context object’s parent.
-	const parent = contextObject.parentNode;
+export function replaceWithNodes(thisObject: Node & ChildNode, nodes: (Node | string)[]): void {
+	// 1. Let parent be this’s parent.
+	const parent = thisObject.parentNode;
 
 	// 2. If parent is null, then return.
 	if (parent === null) {
 		return;
 	}
 
-	// 3. Let viableNextSibling be context object’s first following sibling not in nodes, and null
+	// 3. Let viableNextSibling be this’s first following sibling not in nodes, and null
 	// otherwise.
-	let viableNextSibling = contextObject.nextSibling;
+	let viableNextSibling = thisObject.nextSibling;
 	while (viableNextSibling !== null && nodes.indexOf(viableNextSibling) >= 0) {
 		viableNextSibling = viableNextSibling.nextSibling;
 	}
 
-	// 4. Let node be the result of converting nodes into a node, given nodes and context object’s
+	// 4. Let node be the result of converting nodes into a node, given nodes and this’s
 	// node document.
-	const node = convertNodesIntoNode(nodes, getNodeDocument(contextObject));
+	const node = convertNodesIntoNode(nodes, getNodeDocument(thisObject));
 
-	// 5. If context object’s parent is parent, replace the context object with node within parent.
-	// Note: Context object could have been inserted into node.
-	if (contextObject.parentNode === parent) {
-		replaceChildWithNode(contextObject, node, parent);
+	// 5. If this’s parent is parent, replace the this with node within parent.
+	// Note: this could have been inserted into node.
+	if (thisObject.parentNode === parent) {
+		replaceChildWithNode(thisObject, node, parent);
 	} else {
 		// 6. Otherwise, pre-insert node into parent before viableNextSibling.
 		preInsertNode(node, parent, viableNextSibling);
@@ -941,14 +967,14 @@ export function replaceWithNodes(contextObject: Node & ChildNode, nodes: (Node |
 /**
  * The remove() method, when invoked, must run these steps:
  *
- * @param contextObject The ChildNode on which the method is invoked
+ * @param thisObject The ChildNode on which the method is invoked
  */
-export function removeFromParent(contextObject: Node & ChildNode): void {
-	// 1. If context object’s parent is null, then return.
-	if (contextObject.parentNode === null) {
+export function removeFromParent(thisObject: Node & ChildNode): void {
+	// 1. If this’s parent is null, then return.
+	if (thisObject.parentNode === null) {
 		return;
 	}
 
-	// 2. Remove the context object from context object’s parent.
-	removeNode(contextObject, contextObject.parentNode);
+	// 2. Remove the this.
+	removeNode(thisObject);
 }

--- a/src/util/namespaceHelpers.ts
+++ b/src/util/namespaceHelpers.ts
@@ -172,7 +172,7 @@ export function validateQualifiedName(qualifiedName: string): void {
 	// (QName is basically (Name without ':') ':' (Name without ':'), so just check the position of
 	// the ':')
 	if (!isValidQName(qualifiedName) || !matchesNameProduction(qualifiedName)) {
-		throwInvalidCharacterError('The qualified name is not a valid Name or QName');
+		throwInvalidCharacterError('The qualified name is not a valid QName');
 	}
 }
 
@@ -245,7 +245,7 @@ export function validateAndExtract(
  * @returns The prefix, or null if there isn't one
  */
 export function locateNamespacePrefix(element: Element, namespace: string | null): string | null {
-	// 1. If element’s namespace is namespace and its namespace prefix is not null, then return its
+	// 1. If element’s namespace is namespace and its namespace prefix is non-null, then return its
 	// namespace prefix.
 	if (element.namespaceURI === namespace && element.prefix !== null) {
 		return element.prefix;
@@ -260,7 +260,7 @@ export function locateNamespacePrefix(element: Element, namespace: string | null
 		return attr.localName;
 	}
 
-	// 3. If element’s parent element is not null, then return the result of running locate a
+	// 3. If element’s parent element is non-null, then return the result of running locate a
 	// namespace prefix on that element using namespace.
 	if (element.parentElement !== null) {
 		return locateNamespacePrefix(element.parentElement, namespace);

--- a/test/Document.tests.ts
+++ b/test/Document.tests.ts
@@ -442,4 +442,16 @@ describe('Document', () => {
 			expect(() => document.append('text')).toThrow('HierarchyRequestError');
 		});
 	});
+
+	describe('.replaceChildren', () => {
+		it('can replace all children', () => {
+			const comment = document.appendChild(document.createComment('test'));
+			const pi = document.createProcessingInstruction('target', 'data');
+			document.replaceChildren(pi);
+
+			expect(document.firstChild).toBe(pi);
+			expect(document.lastChild).toBe(pi);
+			expect(comment.parentNode).toBe(null);
+		});
+	});
 });

--- a/test/Document.tests.ts
+++ b/test/Document.tests.ts
@@ -119,6 +119,107 @@ describe('Document', () => {
 		});
 	});
 
+	describe('.getElementsByTagName', () => {
+		it('can find all descendants matching the given qualifiedName', () => {
+			const root = document.appendChild(document.createElement('root'));
+			const e1 = root.appendChild(document.createElementNS('namespace', 'pre:elem'));
+			const e2 = root.appendChild(document.createElementNS('namespace', 'pre:elem'));
+			const other = root.appendChild(document.createElementNS(null, 'other'));
+			const e3 = other.appendChild(document.createElementNS('otherns', 'pre:elem'));
+			const e4 = other.appendChild(document.createElementNS('otherns', 'pre:elem'));
+			const e5 = other.appendChild(document.createElementNS('otherns', 'x:elem'));
+			const e6 = other.appendChild(document.createElementNS('otherns', 'x:elem'));
+
+			expect(document.getElementsByTagName('root')).toEqual([root]);
+			expect(document.getElementsByTagName('pre:elem')).toEqual([e1, e2, e3, e4]);
+			expect(document.getElementsByTagName('other')).toEqual([other]);
+			expect(document.getElementsByTagName('x:elem')).toEqual([e5, e6]);
+		});
+
+		it('can find all descendant elements using the special name "*"', () => {
+			const root = document.appendChild(document.createElement('root'));
+			const e1 = root.appendChild(document.createElementNS('namespace', 'pre:elem'));
+			const e2 = root.appendChild(document.createElementNS('namespace', 'pre:elem'));
+			const other = root.appendChild(document.createElementNS(null, 'other'));
+			const e3 = other.appendChild(document.createElementNS('otherns', 'pre:elem'));
+			const e4 = other.appendChild(document.createElementNS('otherns', 'pre:elem'));
+			const e5 = other.appendChild(document.createElementNS('otherns', 'x:elem'));
+			const e6 = other.appendChild(document.createElementNS('otherns', 'x:elem'));
+
+			expect(document.getElementsByTagName('*')).toEqual([
+				root,
+				e1,
+				e2,
+				other,
+				e3,
+				e4,
+				e5,
+				e6,
+			]);
+		});
+	});
+
+	describe('.getElementsByTagNameNS', () => {
+		it('can find all descendants matching the given namespace and localName', () => {
+			const root = document.appendChild(document.createElement('root'));
+			const e1 = root.appendChild(document.createElementNS('namespace', 'pre:elem'));
+			const e2 = root.appendChild(document.createElementNS('namespace', 'pre:elem'));
+			const other = root.appendChild(document.createElementNS(null, 'other'));
+			const e3 = other.appendChild(document.createElementNS('otherns', 'pre:elem'));
+			const e4 = other.appendChild(document.createElementNS('otherns', 'pre:elem'));
+			const e5 = other.appendChild(document.createElementNS('otherns', 'x:elem'));
+			const e6 = other.appendChild(document.createElementNS('otherns', 'x:elem'));
+
+			expect(document.getElementsByTagNameNS(null, 'root')).toEqual([root]);
+			expect(document.getElementsByTagNameNS('zoinks', 'root')).toEqual([]);
+			expect(document.getElementsByTagNameNS('namespace', 'elem')).toEqual([e1, e2]);
+			expect(document.getElementsByTagNameNS('otherns', 'elem')).toEqual([e3, e4, e5, e6]);
+			expect(document.getElementsByTagNameNS('', 'other')).toEqual([other]);
+		});
+
+		it('can find all descendant elements using the special namespace "*"', () => {
+			const root = document.appendChild(document.createElement('root'));
+			const e1 = root.appendChild(document.createElementNS('namespace', 'pre:elem'));
+			const e2 = root.appendChild(document.createElementNS('namespace', 'pre:elem'));
+			const other = root.appendChild(document.createElementNS(null, 'other'));
+			const e3 = other.appendChild(document.createElementNS('otherns', 'pre:elem'));
+			const e4 = other.appendChild(document.createElementNS('otherns', 'pre:elem'));
+			const e5 = other.appendChild(document.createElementNS('otherns', 'x:elem'));
+			const e6 = other.appendChild(document.createElementNS('otherns', 'x:elem'));
+
+			expect(document.getElementsByTagNameNS('*', 'root')).toEqual([root]);
+			expect(document.getElementsByTagNameNS('*', 'elem')).toEqual([e1, e2, e3, e4, e5, e6]);
+			expect(document.getElementsByTagNameNS('*', 'other')).toEqual([other]);
+		});
+
+		it('can find all descendant elements using the special localName "*"', () => {
+			const root = document.appendChild(document.createElement('root'));
+			const e1 = root.appendChild(document.createElementNS('namespace', 'pre:elem'));
+			const e2 = root.appendChild(document.createElementNS('namespace', 'pre:elem'));
+			const other = root.appendChild(document.createElementNS(null, 'other'));
+			const e3 = other.appendChild(document.createElementNS('otherns', 'pre:elem'));
+			const e4 = other.appendChild(document.createElementNS('otherns', 'pre:elem'));
+			const e5 = other.appendChild(document.createElementNS('otherns', 'x:elem'));
+			const e6 = other.appendChild(document.createElementNS('otherns', 'x:elem'));
+
+			expect(document.getElementsByTagNameNS(null, '*')).toEqual([root, other]);
+			expect(document.getElementsByTagNameNS('', '*')).toEqual([root, other]);
+			expect(document.getElementsByTagNameNS('zoinks', '*')).toEqual([]);
+			expect(document.getElementsByTagNameNS('namespace', '*')).toEqual([e1, e2]);
+			expect(document.getElementsByTagNameNS('otherns', '*')).toEqual([e3, e4, e5, e6]);
+			expect(document.getElementsByTagNameNS('*', '*')).toEqual([
+				root,
+				e1,
+				e2,
+				other,
+				e3,
+				e4,
+				e5,
+				e6,
+			]);
+		});
+	});
+
 	describe('.cloneNode', () => {
 		beforeEach(() => {
 			document.appendChild(document.createElement('root'));

--- a/test/DocumentFragment.tests.ts
+++ b/test/DocumentFragment.tests.ts
@@ -150,4 +150,17 @@ describe('DocumentFragment', () => {
 			expect(fragment.lastChild).toBe(pi);
 		});
 	});
+
+	describe('.replaceChildren', () => {
+		it('can replace all children', () => {
+			const comment = fragment.appendChild(document.createComment('test'));
+			const pi = document.createProcessingInstruction('target', 'data');
+			fragment.replaceChildren(pi, 'text');
+
+			expect(fragment.firstChild).toBe(pi);
+			expect(fragment.lastChild!.nodeType).toBe(slimdom.Node.TEXT_NODE);
+			expect(fragment.lastChild!.nodeValue).toBe('text');
+			expect(comment.parentNode).toBe(null);
+		});
+	});
 });

--- a/test/Element.tests.ts
+++ b/test/Element.tests.ts
@@ -765,4 +765,16 @@ describe('Element', () => {
 			expect(element.lastChild).toBe(pi);
 		});
 	});
+
+	describe('.replaceChildren', () => {
+		it('can replace all children', () => {
+			const comment = element.appendChild(document.createComment('test'));
+			const pi = document.createProcessingInstruction('target', 'data');
+			element.replaceChildren(pi);
+
+			expect(element.firstChild).toBe(pi);
+			expect(element.lastChild).toBe(pi);
+			expect(comment.parentNode).toBe(null);
+		});
+	});
 });

--- a/test/MutationObserver.tests.ts
+++ b/test/MutationObserver.tests.ts
@@ -278,6 +278,47 @@ describe('MutationObserver', () => {
 			];
 		},
 
+		'responds to setting textContent': (observer) => {
+			const parent = document.createElement('parent');
+			const oldChild = parent.appendChild(document.createElement('old'));
+			observer.observe(parent, { childList: true });
+
+			parent.textContent = 'new text';
+			const textNode = parent.firstChild!;
+
+			return [
+				{
+					type: 'childList',
+					target: parent,
+					addedNodes: [textNode],
+					removedNodes: [oldChild],
+					nextSibling: null,
+					previousSibling: null,
+				},
+			];
+		},
+
+		'does not respond to setting textContent to empty if there were no children': (
+			observer
+		) => {
+			const parent = document.createElement('parent');
+			observer.observe(parent, { childList: true });
+
+			parent.textContent = '';
+
+			return null;
+		},
+
+		'does not respond to inserting an empty document fragment': (observer) => {
+			const element = document.createElement('test');
+			const fragment = document.createDocumentFragment();
+			observer.observe(element, { childList: true, subtree: true });
+			observer.observe(fragment, { childList: true, subtree: true });
+			element.appendChild(fragment);
+
+			return null;
+		},
+
 		'does not respond to attribute changes if the attributes option is not set': (observer) => {
 			const element = document.createElement('test');
 			observer.observe(element, { attributes: false, childList: true });

--- a/test/StaticRange.tests.ts
+++ b/test/StaticRange.tests.ts
@@ -1,0 +1,82 @@
+import * as slimdom from '../src/index';
+
+describe('StaticRange', () => {
+	let document: slimdom.Document;
+	beforeEach(() => {
+		document = new slimdom.Document();
+	});
+
+	it('can create a range that does not update automatically', () => {
+		const root = document.appendChild(document.createElement('root'));
+		const r = new slimdom.StaticRange({
+			startContainer: root,
+			startOffset: 0,
+			endContainer: root,
+			endOffset: 0,
+		});
+
+		expect(r.startContainer).toBe(root);
+		expect(r.startOffset).toBe(0);
+		expect(r.endContainer).toBe(root);
+		expect(r.endOffset).toBe(0);
+		expect(r.collapsed).toBe(true);
+
+		document.removeChild(root);
+
+		expect(r.startContainer).toBe(root);
+		expect(r.startOffset).toBe(0);
+		expect(r.endContainer).toBe(root);
+		expect(r.endOffset).toBe(0);
+		expect(r.collapsed).toBe(true);
+	});
+
+	it('does not automatically correct inverted ranges', () => {
+		const root = document.appendChild(document.createElement('root'));
+		const r = new slimdom.StaticRange({
+			startContainer: document,
+			startOffset: 1,
+			endContainer: root,
+			endOffset: 0,
+		});
+
+		expect(r.startContainer).toBe(document);
+		expect(r.startOffset).toBe(1);
+		expect(r.endContainer).toBe(root);
+		expect(r.endOffset).toBe(0);
+		expect(r.collapsed).toBe(false);
+
+		document.removeChild(root);
+
+		expect(r.startContainer).toBe(document);
+		expect(r.startOffset).toBe(1);
+		expect(r.endContainer).toBe(root);
+		expect(r.endOffset).toBe(0);
+		expect(r.collapsed).toBe(false);
+	});
+
+	it('throws when attempting to create a range in an attribute', () => {
+		const root = document.appendChild(document.createElement('root'));
+		root.setAttribute('attr', 'value');
+		const attr = root.getAttributeNode('attr')!;
+		expect(() => {
+			new slimdom.StaticRange({
+				startContainer: attr,
+				startOffset: 0,
+				endContainer: attr,
+				endOffset: 0,
+			});
+		}).toThrow('InvalidNodeTypeError');
+	});
+
+	it('throws when attempting to create a range in a doctype', () => {
+		const doctype = document.implementation.createDocumentType('html', '', '');
+		expect(() => {
+			new slimdom.StaticRange({
+				startContainer: document,
+				startOffset: 0,
+				endContainer: doctype,
+				endOffset: 0,
+			});
+		}).toThrow('InvalidNodeTypeError');
+	});
+});

--- a/test/Text.tests.ts
+++ b/test/Text.tests.ts
@@ -235,7 +235,7 @@ describe('Text', () => {
 	});
 
 	describe('wholeText', () => {
-		it('returns the concatenation of the data of the contiguous text nodes of the context object', () => {
+		it('returns the concatenation of the data of the contiguous text nodes of this', () => {
 			const element = document.createElement('parent');
 			element.append('These', ' ', 'are', ' some text nodes');
 			expect((element.childNodes[0] as slimdom.Text).wholeText).toBe(

--- a/test/examples/sizzle/sizzle.d.ts
+++ b/test/examples/sizzle/sizzle.d.ts
@@ -1,0 +1,1 @@
+declare module 'sizzle';

--- a/test/examples/sizzle/sizzle.tests.ts
+++ b/test/examples/sizzle/sizzle.tests.ts
@@ -1,0 +1,23 @@
+import * as slimdom from '../../../src/index';
+
+import Sizzle = require('sizzle');
+
+describe('Example: sizzle integration', () => {
+	it('can use CSS selectors using Sizzle', () => {
+		const document = new slimdom.Document();
+		const root = document.appendChild(document.createElement('root'));
+		const p1 = root.appendChild(document.createElement('p'));
+		const p2 = root.appendChild(document.createElement('p'));
+		const p3 = root.appendChild(document.createElement('p'));
+		const div = root.appendChild(document.createElement('div'));
+		const p4 = div.appendChild(document.createElement('p'));
+		p1.setAttribute('id', 'header');
+		p4.setAttribute('class', 'footer');
+
+		expect(Sizzle('p', document)).toEqual([p1, p2, p3, p4]);
+		expect(Sizzle('div p', document)).toEqual([p4]);
+		expect(Sizzle('p ~ p', document)).toEqual([p2, p3]);
+		expect(Sizzle('#header', document)).toEqual([p1]);
+		expect(Sizzle('.footer', document)).toEqual([p4]);
+	});
+});


### PR DESCRIPTION
This should probably not be merged while whatwg/dom#819 is pending, as the changes to adoption in the insertion algorithm seem to have caused a few issues. For now, I've had to add a non-standard `if (previousSibling === node)` check in `insertNode` as a work-around to make our tests pass - without that `parent.insertBefore(child, child)` would result in an incorrect `previousSibling` on the mutation record.