### PR TITLE
Fix parsing of documents starting with a PI with a target that starts with xml

### DIFF
--- a/src/dom-parsing/grammar.ts
+++ b/src/dom-parsing/grammar.ts
@@ -642,7 +642,7 @@ const XMLDecl: Parser<XMLDeclEvent> = delimited(
 		optional(S)
 	),
 	PI_END,
-	true
+	false
 );
 
 const NameWithPosition = withPosition(map(Name, (name) => ({ name })));

--- a/src/dom-parsing/grammar.ts
+++ b/src/dom-parsing/grammar.ts
@@ -964,7 +964,9 @@ const EntityDecl = preceded(peek(ENTITY_DECL_START), cut(or([GEDecl, PEDecl])));
 
 // [77] TextDecl ::= '<?xml' VersionInfo? EncodingDecl S? '?>'
 const TextDecl: Parser<XMLDeclEvent> = delimited(
-	XML_DECL_START,
+	// PIs may also start with <?xml, but may never have their target be just 'xml'
+	// We can therefore consider it a fatal error if parsing fails after the space
+	followed(XML_DECL_START, peek(S)),
 	followed(
 		then(optional(VersionInfo), EncodingDecl, (version, encoding) => ({
 			type: ParserEventType.XMLDecl,

--- a/test/dom-parsing/__snapshots__/xmlConformance.tests.ts.snap
+++ b/test/dom-parsing/__snapshots__/xmlConformance.tests.ts.snap
@@ -929,11 +929,11 @@ At line 1, character 16:
 `;
 
 exports[`XML Conformance Test Suite IBM XML 1.0 Tests not-wf ibm-not-wf-P24-ibm24n02.xml - Tests VersionInfo with a required field missing. The white space is missing between the key word "xml" and the VersionInfo in the XMLDecl.: ibm-not-wf-P24-ibm24n02.xml 1`] = `
-"Parsing document failed, expected \\"whitespace\\"
-At line 1, character 6:
+"Parsing document failed, expected \\"?>\\"
+At line 1, character 13:
 
 <?xmlversion='1.0' ?>
-     ^"
+            ^"
 `;
 
 exports[`XML Conformance Test Suite IBM XML 1.0 Tests not-wf ibm-not-wf-P24-ibm24n03.xml - Tests VersionInfo with a required field missing. The "=" (equal sign) is missing between the key word "version" and the VersionNum.: ibm-not-wf-P24-ibm24n03.xml 1`] = `

--- a/test/dom-parsing/parseXmlDocument.tests.ts
+++ b/test/dom-parsing/parseXmlDocument.tests.ts
@@ -777,4 +777,15 @@ describe('parseXmlDocument', () => {
 		const doc = slimdom.parseXmlDocument(xml);
 		expect(slimdom.serializeToWellFormedString(doc)).toBe(xml);
 	});
+
+	it('does not accept a PI with a colon in the name as the first thing in the document', () => {
+		const xml = '<?xml:stylesheet type="text/css" href="styles.css"?><xml/>';
+		expect(() => slimdom.parseXmlDocument(xml)).toThrowErrorMatchingInlineSnapshot(`
+		"Parsing document failed, expected \\"name must not contain colon\\"
+		At line 1, character 3:
+
+		<?xml:stylesheet type=\\"text/css\\" href=\\"styles.css\\"?><xml/>
+		  ^"
+	`);
+	});
 });

--- a/test/dom-parsing/parseXmlDocument.tests.ts
+++ b/test/dom-parsing/parseXmlDocument.tests.ts
@@ -771,4 +771,10 @@ describe('parseXmlDocument', () => {
 		            ^^^^^^^^^^^^^^^^^^^"
 	`);
 	});
+
+	it('works with documents starting with a PI that looks like the XML declaration', () => {
+		const xml = '<?xml-stylesheet type="text/css" href="styles.css"?><xml/>';
+		const doc = slimdom.parseXmlDocument(xml);
+		expect(slimdom.serializeToWellFormedString(doc)).toBe(xml);
+	});
 });

--- a/test/dom-parsing/parseXmlFragment.tests.ts
+++ b/test/dom-parsing/parseXmlFragment.tests.ts
@@ -70,4 +70,21 @@ describe('parseXmlFragment', () => {
 			`"fragment is not well-formed - element \\"missing-end-tag\\" is missing a closing tag"`
 		);
 	});
+
+	it('works with fragments starting with a PI that looks like the XML declaration', () => {
+		const xml = '<?xml-stylesheet type="text/css" href="styles.css"?>';
+		const doc = slimdom.parseXmlFragment(xml);
+		expect(slimdom.serializeToWellFormedString(doc)).toBe(xml);
+	});
+
+	it('does not accept a PI with a colon in the name as the first thing in the fragment', () => {
+		const xml = '<?xml:stylesheet type="text/css" href="styles.css"?>';
+		expect(() => slimdom.parseXmlFragment(xml)).toThrowErrorMatchingInlineSnapshot(`
+		"Parsing fragment failed, expected \\"name must not contain colon\\"
+		At line 1, character 3:
+
+		<?xml:stylesheet type=\\"text/css\\" href=\\"styles.css\\"?>
+		  ^"
+	`);
+	});
 });


### PR DESCRIPTION
Thanks @DrRataplan for reporting.

It's perfectly valid for a PI to have a target starting with `'xml'`, and such a PI may occur at the first position in the document. The parser for the XML declaration therefore should not raise a fatal error if it fails to parse after `<?xml`.