### PR TITLE
Protect against entity expansion attacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ const xml3 = slimdom.serializeToWellFormedString(fragment);
 
 This library does not implement HTML parsing, which means no `insertAdjacentHTML` on `Element`, nor `createContextualFragment` on `Range`. The `innerHTML` and `outerHTML` properties are read-only. If you need to parse HTML, see [this example][parse5-example] which shows how to connect the [parse5][parse5] HTML parser with the help of the [dom-treeadapter][dom-treeadapter] library.
 
+To guard against [entity expansion attacks][billion-laughs], the parser by default limits both the number of entities involved in expanding a single top-level entity reference as well as the number of characters such expansion may produce. You can adjust these limits by setting the `maxNestedEntities` (default 64000) and `maxCharsPerEntity` (default 8000000) options when calling `parseXmlDocument`. Please file an issue if you ever need to increase these values for a non-attack input.
+
 ### CSS Selectors and XPath
 
 This library does not implement CSS selectors, which means no `querySelector` / `querySelectorAll` on `ParentNode` and no `closest` / `matches` / `webkitMatchesSelector` on `Element`. This library also does not implement XPath, which means no `XPathResult` / `XPathExpression` / `XPathEvaluator` interfaces and no `createExpression` / `createNSResolver` / `evaluate` on `Document`.
@@ -131,14 +133,15 @@ The following features are missing simply because I have not yet had, or heard o
 -   `attributeFilter` for mutation observers.
 -   `isConnected` / `getRootNode` / `isEqualNode` / `isSameNode` on `Node`
 
+[billion-laughs]: https://en.wikipedia.org/wiki/Billion_laughs_attack
 [dom-adopt-pr]: https://github.com/whatwg/dom/pull/819
+[dom-treeadapter]: https://github.com/RReverser/dom-treeadapter
 [fontoxpath]: https://github.com/FontoXML/fontoxpath/
+[jsdom]: https://github.com/jsdom/jsdom
 [parse5-example]: https://github.com/bwrrp/slimdom.js/tree/main/test/examples/parse5
 [parse5]: https://github.com/inikulin/parse5
-[dom-treeadapter]: https://github.com/RReverser/dom-treeadapter
 [sizzle-example]: https://github.com/bwrrp/slimdom.js/tree/master/test/examples/sizzle
 [sizzle]: https://github.com/jquery/sizzle
-[jsdom]: https://github.com/jsdom/jsdom
 
 ## Contributing
 

--- a/api/slimdom.api.json
+++ b/api/slimdom.api.json
@@ -10160,6 +10160,37 @@
           "implementsTokenRanges": []
         },
         {
+          "kind": "TypeAlias",
+          "canonicalReference": "slimdom!ParseOptions:type",
+          "docComment": "/**\n * Options to control parsing.\n *\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export type ParseOptions = "
+            },
+            {
+              "kind": "Reference",
+              "text": "Partial",
+              "canonicalReference": "!Partial:type"
+            },
+            {
+              "kind": "Content",
+              "text": "<{\n    maxNestedEntities: number;\n    maxCharsPerEntity: number;\n}>"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "lib/dom-parsing/parsingAlgorithms.d.ts",
+          "releaseTag": "Public",
+          "name": "ParseOptions",
+          "typeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          }
+        },
+        {
           "kind": "Function",
           "canonicalReference": "slimdom!parseXmlDocument:function(1)",
           "docComment": "/**\n * Parse an XML document\n *\n * This parser is non-validating, and therefore does not support an external DTD or external parsed entities. During parsing, any referenced entities are included, default attribute values are materialized and the DTD internal subset is discarded. References to external entities are replaced with nothing. References to parameter entities are also ignored.\n *\n * @param input - the string to parse\n *\n * @public\n */\n",
@@ -10171,6 +10202,15 @@
             {
               "kind": "Content",
               "text": "string"
+            },
+            {
+              "kind": "Content",
+              "text": ", options?: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ParseOptions",
+              "canonicalReference": "slimdom!ParseOptions:type"
             },
             {
               "kind": "Content",
@@ -10188,8 +10228,8 @@
           ],
           "fileUrlPath": "lib/dom-parsing/parsingAlgorithms.d.ts",
           "returnTypeTokenRange": {
-            "startIndex": 3,
-            "endIndex": 4
+            "startIndex": 5,
+            "endIndex": 6
           },
           "releaseTag": "Public",
           "overloadIndex": 1,
@@ -10201,6 +10241,14 @@
                 "endIndex": 2
               },
               "isOptional": false
+            },
+            {
+              "parameterName": "options",
+              "parameterTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "isOptional": true
             }
           ],
           "name": "parseXmlDocument"

--- a/api/slimdom.api.md
+++ b/api/slimdom.api.md
@@ -445,7 +445,13 @@ export abstract class Node {
 }
 
 // @public
-export function parseXmlDocument(input: string): Document;
+export type ParseOptions = Partial<{
+    maxNestedEntities: number;
+    maxCharsPerEntity: number;
+}>;
+
+// @public
+export function parseXmlDocument(input: string, options?: ParseOptions): Document;
 
 // @public
 export function parseXmlFragment(input: string, options?: Partial<{

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export { default as MutationRecord } from './mutation-observer/MutationRecord';
 export { DOMException } from './util/errorHelpers';
 
 export { parseXmlDocument, parseXmlFragment } from './dom-parsing/parsingAlgorithms';
+export type { ParseOptions } from './dom-parsing/parsingAlgorithms';
 
 // Standard DOM does not expose a way to serialize arbitrary nodes as well-formed XML
 export { serializeToWellFormedString } from './dom-parsing/XMLSerializer';


### PR DESCRIPTION
This adds options to set limits to how many entities may be involved in expansion of a single top-level entity reference, and how many characters such expansion may produce. Those should default to reasonable values (roughly based on similar options in Java). Please file an issue if you have to increase these limits for any real-world document.