### PR TITLE
Rework ns prefix serialization

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"jest.jestCommandLine": "npm run test --"
+}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Fast, tiny, standards-compliant XML DOM implementation for node and the browser.
 This is a (partial) implementation of the following specifications:
 
 -   [DOM living standard][domstandard], as last updated 19 December 2021
--   [DOM Parsing and Serialization W3C Editor's Draft][domparsing], as last updated 20 April 2020
+-   [DOM Parsing and Serialization W3C Editor's Draft][domparsing], as last updated 2 May 2021
 -   [Extensible Markup Language (XML) 1.0 (Fifth Edition)][xmlstandard]
 -   [Namespaces in XML 1.0 (Third Edition)][xml-names]
 
@@ -37,24 +37,24 @@ The package includes both a commonJS-compatible UMD bundle (`dist/slimdom.umd.js
 
 ## Usage
 
-Create documents using the slimdom.Document constructor, and manipulate them using the [standard DOM API][domstandard].
+Create documents by parsing XML or start from scratch using the slimdom.Document constructor, and manipulate them using the [standard DOM API][domstandard].
 
 ```javascript
 import * as slimdom from 'slimdom';
 // alternatively, in node and other commonJS environments:
 // const slimdom = require('slimdom');
 
-// Start with an empty document:
-const document = new slimdom.Document();
-document.appendChild(document.createElementNS('http://www.example.com', 'root'));
-const xml = slimdom.serializeToWellFormedString(document);
-// -> '<root xmlns="http://www.example.com"/>'
-
-// Or parse from a string:
+// Parse from a string:
 const document2 = slimdom.parseXmlDocument('<root attr="value">Hello!</root>');
 document2.documentElement.setAttribute('attr', 'new value');
 const xml2 = slimdom.serializeToWellFormedString(document2);
 // -> '<root attr="new value">Hello!</root>'
+
+// Or start with an empty document:
+const document = new slimdom.Document();
+document.appendChild(document.createElementNS('http://www.example.com', 'root'));
+const xml = slimdom.serializeToWellFormedString(document);
+// -> '<root xmlns="http://www.example.com"/>'
 ```
 
 Some DOM API's, such as the `DocumentFragment` constructor, require the presence of a global document, for instance to set their initial `ownerDocument` property. In these cases, slimdom will use the instance exposed through `slimdom.document`. Although you could mutate this document, it is recommended to always create your own documents (using the `Document` constructor) to avoid conflicts with other code using slimdom in your application.
@@ -71,11 +71,11 @@ This library implements:
 -   `XMLSerializer`, and read-only versions of `innerHTML` / `outerHTML` on `Element`.
 -   `DOMParser`, for XML parsing only.
 
-This library is currently aimed at providing a lightweight and consistent experience for dealing with XML and XML-like data. For simplicity and efficiency, this implementation deviates from the spec in a few minor ways. Most notably, normal JavaScript arrays are used instead of `HTMLCollection` / `NodeList` and `NamedNodeMap`, HTML documents are treated no different from other documents and a number of features from in the DOM spec are missing. In most cases, this is because alternatives are available that can be used together with slimdom with minimal effort.
+This library is aimed at providing a lightweight and consistent experience for dealing with XML and XML-like data. For simplicity and efficiency, this implementation deviates from the spec in a few minor ways. Most notably, normal JavaScript arrays are used instead of `HTMLCollection` / `NodeList` and `NamedNodeMap`, HTML documents are treated no different from other documents and a number of features from in the DOM spec are missing. In most cases, this is because alternatives are available that can be used together with slimdom with minimal effort.
 
 Do not rely on the behavior or presence of any methods and properties not specified in the DOM standard. For example, do not use JavaScript array methods exposed on properties that should expose a NodeList and do not use Element as a constructor. This behavior is _not_ considered public API and may change without warning in a future release.
 
-This library implements the changes from [whatwg/dom#819][dom-adopt-pr], as the specification as currently described has known bugs around adoption.
+This library implements the changes from [whatwg/dom#819][dom-adopt-pr], as the DOM specification as currently described has known bugs around adoption. It also deviates from the [DOM serialization algorithms][domparsing] that deal with assigning and resolving conflicts in namespace prefixes, as the specification has a number of bugs that currently remain unaddressed.
 
 As serializing XML using the `XMLSerializer` does not enforce well-formedness, you may instead want to use the `serializeToWellFormedString` function which does perform such checks.
 

--- a/api/slimdom.api.json
+++ b/api/slimdom.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.35.1",
+    "toolVersion": "7.38.0",
     "schemaVersion": 1011,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/src/dom-parsing/NamespacePrefixMap.ts
+++ b/src/dom-parsing/NamespacePrefixMap.ts
@@ -1,118 +1,64 @@
+import Attr from '../Attr';
 import Element from '../Element';
+import { isAttrNode } from '../util/NodeType';
 import { XML_NAMESPACE, XMLNS_NAMESPACE } from '../util/namespaceHelpers';
+
+export type PrefixIndex = { value: number };
 
 // 3.2.1.1.2 The Namespace Prefix Map
 
 /**
- * A namespace prefix map is a map that associates namespaceURI and namespace prefix lists, where
- * namespaceURI values are the map's unique keys (which can include the null value representing no
- * namespace), and ordered lists of associated prefix values are the map's key values. The namespace
- * prefix map will be populated by previously seen namespaceURIs and all their previously
- * encountered prefix associations for a given node and its ancestors.
+ * A namespace prefix map is a map that associates namespaceURI and namespace
+ * prefix lists.
  *
- * NOTE: the last seen prefix for a given namespaceURI is at the end of its respective list. The
- * list is searched to find potentially matching prefixes, and if no matches are found for the given
- * namespaceURI, then the last prefix in the list is used. See copy a namespace prefix map and
- * retrieve a preferred prefix string for additional details.
+ * This deviates from the specification to fix a number of bugs in the spec that
+ * can cause it to otherwise produce non-well-formed markup or markup that does
+ * not capture the author's intent.
+ *
+ * Instead of only tracking candidate prefixes by namespace, this also tracks
+ * the current prefix to namespace mapping so we can properly detect when
+ * prefixes have been redefined. This implementation also tracks maps as a tree
+ * to avoid copying as well as the need to separately track locally defined
+ * prefixes.
  */
 export class NamespacePrefixMap {
-	private _map: Map<string | null, string[]> = new Map();
+	private _parent: NamespacePrefixMap | null;
 
-	/**
-	 * To copy a namespace prefix map map means to copy the map's keys into a new empty namespace
-	 * prefix map, and to copy each of the values in the namespace prefix list associated with each
-	 * keys' value into a new list which should be associated with the respective key in the new
-	 * map.
-	 *
-	 * @returns A copy of the namespace prefix map
-	 */
-	public copy(): NamespacePrefixMap {
-		const copy = new NamespacePrefixMap();
-		// Array.from needed to allow compilation to ES5 targets
-		for (const [namespace, prefixes] of Array.from(this._map.entries())) {
-			copy._map.set(namespace, prefixes.concat());
-		}
-		return copy;
+	private _nsByPrefix = new Map<string | null, string | null>();
+
+	private _prefixCandidatesByNs: Map<string | null, (string | null)[]> = new Map();
+
+	private constructor(parent: NamespacePrefixMap | null) {
+		this._parent = parent;
+	}
+
+	public static new(): NamespacePrefixMap {
+		const map = new NamespacePrefixMap(null);
+		// Register implicitly declared namespaces
+		map.add(null, null);
+		map.add('xml', XML_NAMESPACE);
+		map.add('xmlns', XMLNS_NAMESPACE);
+		return map;
 	}
 
 	/**
-	 * To retrieve a preferred prefix string preferred prefix from the namespace prefix map map
-	 * given a namespace ns, the user agent should:
-	 *
-	 * @param preferredPrefix - The prefix to look up
-	 * @param ns              - The namespace for the prefix
-	 *
-	 * @returns The matching candidate prefix, if found, or null otherwise
-	 */
-	public retrievePreferredPrefixString(
-		preferredPrefix: string | null,
-		ns: string | null
-	): string | null {
-		// 1. Let candidates list be the result of retrieving a list from map where there exists a
-		// key in map that matches the value of ns or if there is no such key, then stop running
-		// these steps, and return the null value.
-		const candidatesList = this._map.get(ns);
-		if (candidatesList === undefined) {
-			return null;
-		}
-
-		// 2. Otherwise, for each prefix value prefix in candidates list, iterating from beginning
-		// to end:
-		// NOTE: There will always be at least one prefix value in the list.
-		for (const prefix of candidatesList) {
-			// 2.1. If prefix matches preferred prefix, then stop running these steps and return
-			// prefix.
-			if (prefix === preferredPrefix) {
-				return prefix;
-			}
-
-			// 2.2. If prefix is the last item in the candidates list, then stop running these steps
-			// and return prefix.
-		}
-		return candidatesList[candidatesList.length - 1];
-	}
-
-	/**
-	 * To check if a prefix string prefix is found in a namespace prefix map map given a namespace
-	 * ns, the user agent should:
-	 *
-	 * @param prefix - The prefix to check
-	 * @param ns     - The namespace to check
-	 *
-	 * @returns Whether the combination of prefix and ns is found in the map
-	 */
-	public checkIfFound(prefix: string, ns: string | null): boolean {
-		// 1. Let candidates list be the result of retrieving a list from map where there exists a
-		// key in map that matches the value of ns or if there is no such key, then stop running
-		// these steps, and return false.
-		const candidatesList = this._map.get(ns);
-		if (candidatesList === undefined) {
-			return false;
-		}
-
-		// 2. If the value of prefix occurs at least once in candidates list, return true, otherwise
-		// return false.
-		return candidatesList.indexOf(prefix) >= 0;
-	}
-
-	/**
-	 * To add a prefix string prefix to the namespace prefix map map given a namespace ns, the user
-	 * agent should:
+	 * To add a prefix string prefix to the namespace prefix map map given a
+	 * namespace ns, the user agent should:
 	 *
 	 * @param prefix - The prefix to add
 	 * @param ns     - The namespace to add for prefix
 	 */
-	public add(prefix: string, ns: string | null): void {
+	public add(prefix: string | null, ns: string | null): void {
 		// 1. Let candidates list be the result of retrieving a list from map where there exists a
 		// key in map that matches the value of ns or if there is no such key, then let candidates
 		// list be null.
 		// (undefined used instead of null for convenience)
-		const candidatesList = this._map.get(ns);
+		const candidatesList = this._prefixCandidatesByNs.get(ns);
 
 		// 2. If candidates list is null, then create a new list with prefix as the only item in the
 		// list, and associate that list with a new key ns in map.
 		if (candidatesList === undefined) {
-			this._map.set(ns, [prefix]);
+			this._prefixCandidatesByNs.set(ns, [prefix]);
 		} else {
 			// 3. Otherwise, append prefix to the end of candidates list.
 			candidatesList.push(prefix);
@@ -122,102 +68,126 @@ export class NamespacePrefixMap {
 		// recently used (MRU) prefix associated with a given namespace, which will be the prefix at
 		// the end of the list. This list may contain duplicates of the same prefix value seen
 		// earlier (and that's OK).
+
+		this._nsByPrefix.set(prefix, ns);
 	}
-}
 
-export type LocalPrefixesMap = { [key: string]: string | null };
-
-// 3.2.1.1.1 Recording the namespace
-
-/**
- * This following algorithm will update the namespace prefix map with any found namespace prefix
- * definitions, add the found prefix definitions to the local prefixes map, and return a local
- * default namespace value defined by a default namespace attribute if one exists. Otherwise it
- * returns null.
- *
- * @param element          - Element for which to record namespace information
- * @param map              - The namespace prefix map to update
- * @param localPrefixesMap - The local prefixes map to update
- *
- * @returns The local default namespace value for element, or null if element does not define one
- */
-export function recordNamespaceInformation(
-	element: Element,
-	map: NamespacePrefixMap,
-	localPrefixesMap: LocalPrefixesMap
-): string | null {
-	// 1. Let default namespace attr value be null.
-	let defaultNamespaceAttrValue: string | null = null;
-
-	// 2. Main: For each attribute attr in element's attributes, in the order they are specified in
-	// the element's attribute list:
-	// NOTE: The following conditional steps find namespace prefixes. Only attributes in the XMLNS
-	// namespace are considered (e.g., attributes made to look like namespace declarations via
-	// setAttribute("xmlns:pretend-prefix", "pretend-namespace") are not included).
-	for (const attr of element.attributes) {
-		// 2.1. Let attribute namespace be the value of attr's namespaceURI value.
-		const attributeNamespace = attr.namespaceURI;
-
-		// 2.2. Let attribute prefix be the value of attr's prefix.
-		const attributePrefix = attr.prefix;
-
-		// 2.3. If the attribute namespace is the XMLNS namespace, then:
-		if (attributeNamespace === XMLNS_NAMESPACE) {
-			// 2.3.1. If attribute prefix is null, then attr is a default namespace declaration. Set
-			// the default namespace attr value to attr's value and stop running these steps,
-			// returning to Main to visit the next attribute.
-			if (attributePrefix === null) {
-				defaultNamespaceAttrValue = attr.value;
+	public recordNamespaceInformation(element: Element): NamespacePrefixMap {
+		const map = new NamespacePrefixMap(this);
+		for (const attr of element.attributes) {
+			if (attr.namespaceURI !== XMLNS_NAMESPACE) {
+				// Not a namespace declaration attribute
 				continue;
 			}
 
-			// 2.3.2. Otherwise, the attribute prefix is non-null and attr is a namespace prefix
-			// definition. Run the following steps:
-			// 2.3.2.1. Let prefix definition be the value of attr's localName.
-			const prefixDefinition = attr.localName;
-
-			// 2.3.2.2. Let namespace definition be the value of attr's value.
-			let namespaceDefinition: string | null = attr.value;
-
-			// 2.3.2.3. If namespace definition is the XML namespace, then stop running these steps,
-			// and return to Main to visit the next attribute.
-			// NOTE: XML namespace definitions in prefixes are completely ignored (in order to avoid
-			// unnecessary work when there might be prefix conflicts). XML namespaced elements are
-			// always handled uniformly by prefixing (and overriding if necessary) the element's
-			// localname with the reserved "xml" prefix.
-			if (namespaceDefinition === XML_NAMESPACE) {
-				continue;
-			}
-
-			// 2.3.2.4. If namespace definition is the empty string (the declarative form of having
-			// no namespace), then let namespace definition be null instead.
-			if (namespaceDefinition === '') {
-				namespaceDefinition = null;
-			}
-
-			// 2.3.2.5. If prefix definition is found in map given the namespace namespace
-			// definition, then stop running these steps, and return to Main to visit the next
-			// attribute.
-			// NOTE: This step avoids adding duplicate prefix definitions for the same namespace in
-			// the map. This has the side-effect of avoiding later serialization of duplicate
-			// namespace prefix declarations in any descendant nodes.
-			if (map.checkIfFound(prefixDefinition, namespaceDefinition)) {
-				continue;
-			}
-
-			// 2.3.2.6. Add the prefix prefix definition to map given namespace namespace
-			// definition.
-			map.add(prefixDefinition, namespaceDefinition);
-
-			// 2.3.2.7. Add the value of prefix definition as a new key to the local prefixes map,
-			// with the namespace definition as the key's value replacing the value of null with the
-			// empty string if applicable.
-			localPrefixesMap[prefixDefinition] =
-				namespaceDefinition === null ? '' : namespaceDefinition;
+			const namespaceUri = attr.value === '' ? null : attr.value;
+			const definedPrefix = attr.prefix === null ? null : attr.localName;
+			map.add(definedPrefix, namespaceUri);
 		}
+		return map;
 	}
 
-	// 3. Return the value of default namespace attr value.
-	// NOTE: The empty string is a legitimate return value and is not converted to null.
-	return defaultNamespaceAttrValue;
+	private _localPrefixToNamespace(prefix: string | null): string | null | undefined {
+		return this._nsByPrefix.get(prefix);
+	}
+
+	private _inheritedPrefixToNamespace(prefix: string | null): string | null | undefined {
+		return this._parent?.prefixToNamespace(prefix);
+	}
+
+	public prefixToNamespace(prefix: string | null): string | null | undefined {
+		const ns = this._localPrefixToNamespace(prefix);
+		if (ns !== undefined) {
+			return ns;
+		}
+		return this._inheritedPrefixToNamespace(prefix);
+	}
+
+	public shouldSerializeDeclaration(prefix: string | null, ns: string | null): boolean {
+		// An existing declaration attribute should be skipped if it doesn't
+		// match the local scope. It can be skipped if it doesn't change the
+		// inherited value.
+		return this.prefixToNamespace(prefix) === ns && this._inheritedPrefixToNamespace(prefix) !== ns;
+	}
+
+	private _getCandidatePrefix(namespaceUri: string | null): string | null | undefined {
+		const candidates = this._prefixCandidatesByNs.get(namespaceUri);
+		if (candidates !== undefined) {
+			for (let i = candidates.length - 1; i >= 0; --i) {
+				const candidate = candidates[i];
+				if (this.prefixToNamespace(candidate) === namespaceUri) {
+					return candidate;
+				}
+			}
+		}
+		return undefined;
+	}
+
+	public getPreferredPrefix(node: Element | Attr, prefixIndex: PrefixIndex): string | null {
+		// XML namespace must use the "xml" prefix
+		if (node.namespaceURI === XML_NAMESPACE) {
+			return 'xml';
+		}
+
+		// XMLNS namespace must use "xmlns", except for default namespace
+		// declarations, which use no prefix
+		const isAttr = isAttrNode(node);
+		if (node.namespaceURI === XMLNS_NAMESPACE) {
+			if (isAttr && node.prefix === null) {
+				return null;
+			}
+			return 'xmlns';
+		}
+
+		// attributes in the null namespace don't have a prefix
+		if (isAttr && node.namespaceURI === null) {
+			return null;
+		}
+
+		// elements use no prefix if their namespace is the inherited default
+		// namespace
+		if (!isAttr) {
+			let inheritedNs = this._inheritedPrefixToNamespace(null) ?? null;
+			if (node.namespaceURI === inheritedNs) {
+				// The caller should add this to the map to ensure that any
+				// current default namespace declaration is ignored.
+				return null;
+			}
+		}
+
+		// If the authored prefix resolves to the requested namespace in scope,
+		// we can use it, except that attributes in a namespace can't use an
+		// empty prefix.
+		if ((!isAttr || node.prefix !== null) && this.prefixToNamespace(node.prefix) === node.namespaceURI) {
+			return node.prefix;
+		}
+
+		// If any prefixes in scope resolve to the requested namespace, use the
+		// most recent one.
+		const candidatePrefix = this._getCandidatePrefix(node.namespaceURI);
+		if (candidatePrefix !== undefined) {
+			return candidatePrefix;
+		}
+
+		// No suitable existing declaration, try to use the authored prefix
+
+		// Attributes can't use the authored prefix if it conflicts with an existing local declaration
+		if (isAttr) {
+			const namespaceForPrefix = this._localPrefixToNamespace(node.prefix);
+			const isValidPrefix = node.prefix !== null && (namespaceForPrefix === undefined || namespaceForPrefix === node.namespaceURI);
+
+			if (!isValidPrefix) {
+				// Collision - generate a new prefix
+				while (true) {
+					const generatedPrefix = `ns${prefixIndex.value}`;
+					prefixIndex.value += 1;
+					if (this._localPrefixToNamespace(generatedPrefix) === undefined) {
+						return generatedPrefix;
+					}
+				}
+			}
+		}
+
+		return node.prefix;
+	}
 }


### PR DESCRIPTION
This re-implements the algorithms used to determine what prefixes to assign and what declarations to output for them during serialization. The algorithms in the DOM parsing and serialization spec contain too many bugs that have so far not been addressed, and contain complicated branching that makes it hard to reason about them.

In the replacement I've tried to remain close to the original behavior in spirit. That is, existing prefixes (or an inherited default namespace) are preferred over authored prefixes. Authored prefixes are used over generated ones. A new prefix is only generated if the authored prefix of an attribute conflicts with a declaration on the same element. Declaration attributes in the DOM are only preserved if they actually represent a change to the namespaces in scope for their element and do not cause conflicts - the spec preserved default namespace declarations in a few other cases but those seemed unnecessary.