### PR TITLE
[FIX] Add "types" to the "exports" section of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 	"type": "module",
 	"exports": {
 		".": {
+			"types": "./dist/slimdom.d.ts",
 			"import": "./dist/slimdom.esm.js",
 			"require": "./dist/slimdom.umd.cjs",
 			"default": "./dist/slimdom.esm.js"


### PR DESCRIPTION
When using `"module": "NodeNext"`, Typescript expects to find a `"types"` property in the package.json `"exports"` declaration - see [docs](https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports).

Because `slimdom.js` does not, I receive this error.

```
Could not find a declaration file for module 'slimdom'. '/node_modules/.pnpm/slimdom@4.3.3/node_modules/slimdom/dist/slimdom.esm.js' implicitly has an 'any' type.
  There are types at '/node_modules/slimdom/dist/slimdom.d.ts', but this result could not be resolved when respecting package.json "exports". The 'slimdom' library may need to update its package.json or typings.ts
```

I have tested this locally, and this resolves the issue.